### PR TITLE
Drop index issue fixed

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -443,7 +443,7 @@ module.exports = function (PersistObjectTemplate) {
                         if (operation === 'add')
                             return table[type](columns, name);
                         else if (operation === 'dels')
-                            return table['drop' + type.replace(/index/, 'Index')](name);
+                            return table['drop' + type.replace(/index/, 'Index')]([], name);
                         else
                             return table[type](columns, name);
                     }


### PR DESCRIPTION
Need to include empty array when dropping the index, or else knex is generating the name using table  and field names.