### PR TITLE
Table synchronization fixes.

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -6,104 +6,6 @@ module.exports = function (PersistObjectTemplate) {
     var _ = require('underscore');
 
     /**
-     * Save the schema so we can keep track of indexes. Must be called before tables are synchronized
-     * Should maybe be incorporated in setSchema as a trackIndexes option.
-     * @param alias
-     * @returns {*}
-     */
-    PersistObjectTemplate.saveSchema = function (alias) {
-
-        var knex = this.getDB(alias).connection;
-        var maxdbversion;
-        var schemaTable = 'haven_schema1';
-        var schemaField = 'schema';
-        var latestVersion = 1;
-        this._schematracker = this._schematracker || {};
-        this._schemacache = {};
-
-        var isSchemaUpdated = function(){
-            return _.keys(this._schematracker.adds).length > 0 ||
-                _.keys(this._schematracker.changes).length > 0 ||
-                _.keys(this._schematracker.dels).length > 0
-        }.bind(this)
-
-        var updateSchema = (function () {
-            if (isSchemaUpdated) {
-                return knex(schemaTable).insert({
-                    sequence_id: ++latestVersion,
-                    schema: JSON.stringify(this._schema)
-                })
-            }
-            return Promise.resolve();
-        }).bind(this);
-
-        var diff = (function (memSchema, dbSchema) {
-            var track = {add: {}, change: {}, delete: {}};
-            _diff(dbSchema, memSchema, 'delete', true, function (dbIdx, memIdx) {
-                return !memIdx;
-            }, _diff(memSchema, dbSchema, 'change', false, function (memIdx, dbIdx) {
-                return memIdx && dbIdx && !_.isEqual(memIdx, dbIdx);
-            }, _diff(memSchema, dbSchema, 'add', true, function (memIdx, dbIdx) {
-                return !dbIdx;
-            }, track)));
-
-            this._schematracker.dels = track.delete;
-            this._schematracker.changes = track.change;
-            this._schematracker.adds = track.add;
-
-            function _diff(masterSchema, shadowSchema, opr, addMissingTable, addPredicate, diffs) {
-                return Object.keys(masterSchema).reduce(function (diffs, table) {
-                    if (shadowSchema[table]) {
-                        (masterSchema[table].indexes || []).forEach(function (mstIdx) {
-                            var shdIdx = _.findWhere(shadowSchema[table].indexes, {name: mstIdx.name});
-
-                            if (addPredicate(mstIdx, shdIdx)) {
-                                diffs[opr][table] = diffs[opr][table] || [];
-                                diffs[opr][table].push(mstIdx);
-                            }
-                        });
-                    } else {
-                        diffs[opr][table] = diffs[opr][table] || [];
-                        diffs[opr][table].push.apply(diffs[opr][table], masterSchema[table].indexes);
-                    }
-                    return diffs;
-                }, diffs);
-            }
-        }).bind(this);
-
-        var processDataAndUpdate = (function (dbSchema) {
-            var currentschema = this._schema;
-            var prevschema = {};
-            if (dbSchema && dbSchema.schema)
-                prevschema = JSON.parse(dbSchema.schema);
-            diff(currentschema, prevschema);
-        }).bind(this);
-
-
-        function storeSchemaAndExtractChanges(alias) {
-            var cx = this;
-            return knex.schema.createTableIfNotExists(schemaTable, function (table) {
-                table.increments('sequence_id').primary();
-                table.text(schemaField);
-                table.timestamps();
-            }).then(function () {
-                return knex(schemaTable)
-                    .orderBy('sequence_id', 'desc')
-                    .limit(1)
-            }).then(function (record) {
-                if (record[0] !== undefined)
-                    latestVersion = record[0].sequence_id;
-                return Promise.resolve().then(processDataAndUpdate(record[0]));
-            }).then(updateSchema).catch(function (error) {
-                throw error;
-            });
-        }
-
-        return storeSchemaAndExtractChanges.call(this, alias);
-    }
-
-
-    /**
      * Get a POJO by reading a table, optionally joining it to other tables
      *
      * @param template
@@ -404,13 +306,13 @@ module.exports = function (PersistObjectTemplate) {
      * @param template
      * @returns {*}
      */
-    PersistObjectTemplate.synchronizeKnexTableFromTemplate = function (template) {
+    PersistObjectTemplate.synchronizeKnexTableFromTemplate = function (template, changeNotificationCallback) {
         var aliasedTableName = template.__table__;
         var tableName = this.dealias(aliasedTableName);
-        (function (){
-            while(template.__parent__)
-                template =  template.__parent__;
-        })();
+
+        while(template.__parent__)
+            template =  template.__parent__;
+
         if(!template.__table__)
             throw new Error(template.__name__ + " is missing a schema entry");
 
@@ -418,54 +320,33 @@ module.exports = function (PersistObjectTemplate) {
         var knex = this.getDB(this.getDBAlias(template.__table__)).connection
         var schema = template.__schema__;
         var _newFields = {};
-        return Promise.resolve().then(function(){
-            return knex.schema.hasTable(tableName).then(function (exists) {
-                if (!exists) {
-                    return PersistObjectTemplate.createKnexTable(template, aliasedTableName);
-                }
-                else {
-                    return discoverColumns(tableName).then(function () {
-                        return knex.schema.table(tableName, columnMapper.bind(this))
-                    }.bind(this));
-                }
-            }.bind(this))}.bind(this));
 
-        function synchronizeIndexes(table) {
-            _.each(Object.getOwnPropertyNames(this._schematracker), function (key) {
-                var templateClone = _.clone(template);
-                syncIndexesForHierarchy.call(this, key, templateClone);
-            }.bind(this));
-
-            function syncIndexesForHierarchy (operation, templateClone) {
-                var tn = templateClone.__name__;
-                _.map(this._schematracker[operation][tn], (function (object, key) {
-                    var type = object.def.type;
-                    var columns = object.def.columns;
-                    var name = _.reduce(object.def.columns, function (name, col) {
-                        return name + '_' + col;
-                    }, 'idx_' + tableName);
-
-                    //var name = 'idx_' + tableName + '_' + object.name;
-                    if (!this._schemacache[name]) {
-                        this._schemacache[name] = true;
-                        if (operation === 'add')
-                            return table[type](columns, name);
-                        else if (operation === 'dels') {
-                            type= type.replace(/index/, 'Index');
-                            type = type.replace(/unique/, 'Unique')
-                            return table['drop' + type]([], name);
-                        }
-                        else
-                            return table[type](columns, name);
+        return Promise.resolve().then(function () {
+                return knex.schema.hasTable(tableName).then(function (exists) {
+                    if (!exists) {
+                        if (!!changeNotificationCallback) changeNotificationCallback('A new table, ' + tableName + ', has been added\n');
+                        return PersistObjectTemplate._createKnexTable(template, aliasedTableName);
                     }
-
-                }).bind(this));
-                templateClone.__children__.forEach(function (o) {
-                    syncIndexesForHierarchy.call(this, operation, o);
+                    else {
+                        return discoverColumns(tableName).then(function () {
+                            fieldChangeNotify(changeNotificationCallback, tableName);
+                            return knex.schema.table(tableName, columnMapper.bind(this))
+                        }.bind(this));
+                    }
                 }.bind(this))
-            };
-        };
+            }.bind(this))
+            .then(synchronizeIndexes.bind(this, tableName, template));
 
+        function fieldChangeNotify(callBack, table) {
+            if (!callBack) return;
+            if (typeof callBack !== 'function')
+                throw new Error('persistor can only notify the field changes through a callback');
+            console.log('field change verification')
+
+            var fieldsChanged = _.keys(_newFields).join();
+
+            callBack('Following fields are being added to ' + table + ' table: \n    ' + fieldsChanged);
+        }
         function columnMapper(table) {
 
             for (var prop in _newFields) {
@@ -490,7 +371,6 @@ module.exports = function (PersistObjectTemplate) {
                 } else
                     table.text(prop);
             }
-            synchronizeIndexes.call(this, table);
         }
 
 
@@ -521,35 +401,246 @@ module.exports = function (PersistObjectTemplate) {
                 return prop;
             }
         }
+    }
 
-        function iscompatible(persistortype, pgtype) {
-            switch (persistortype) {
-                case 'String':
-                case 'Object':
-                case 'Array':
-                    return pgtype.indexOf('text') > -1;
-                case 'Number':
-                    return pgtype.indexOf('double precision') > -1;
-                case 'Boolean':
-                    return pgtype.indexOf('bool') > -1;
-                case 'Date':
-                    return pgtype.indexOf('timestamp') > -1;
-                default:
-                    return pgtype.indexOf('text') > -1; // Typed objects have no name
+    function synchronizeIndexes(tableName, template) {
+
+        var aliasedTableName = template.__table__;
+        var tableName = this.dealias(aliasedTableName);
+
+        while(template.__parent__)
+            template =  template.__parent__;
+
+        if(!template.__table__)
+            throw new Error(template.__name__ + " is missing a schema entry");
+
+        var props = getPropsRecursive(template);
+        var knex = this.getDB(this.getDBAlias(template.__table__)).connection
+        var schema = template.__schema__;
+        var _newFields = {};
+
+        var _dbschema, _templateSchema = {};
+        var _changes =  {};
+        var schemaTable = 'haven_schema1';
+        var schemaField = 'schema';
+
+
+        var loadSchema = function (tableName) {
+
+            if (!!_dbschema) return(_dbschema, tableName);
+
+            return  knex.schema.createTableIfNotExists(schemaTable, function (table) {
+                table.increments('sequence_id').primary();
+                table.text(schemaField);
+                table.timestamps();
+            }).then(function () {
+                return knex(schemaTable)
+                    .orderBy('sequence_id', 'desc')
+                    .limit(1);
+            }).then(function (record) {
+                var response;
+                if (!record[0]) {
+                    response = {};
+                }
+                else {
+                    latestVersion = record[0].sequence_id;
+                    response = JSON.parse(record[0][schemaField]);
+                }
+                _dbschema = response;
+                return [response, schema, tableName];
+            })
+        }
+
+        var loadTableDef = function(dbschema, schema, tableName) {
+            _templateSchema[tableName] = schema
+            if (!dbschema[tableName])
+                dbschema[tableName] = {};
+            return [dbschema[tableName], schema, tableName];
+        }
+
+        var diffTable = function(dbTableDef, memTableDef, tableName){
+            var track = {add: [], change: [], delete: []};
+            _diff(dbTableDef, memTableDef, 'delete', false, function (dbIdx, memIdx) {
+                return !memIdx;
+            }, _diff(memTableDef, dbTableDef, 'change', false, function (memIdx, dbIdx) {
+                return memIdx && dbIdx && !_.isEqual(memIdx, dbIdx);
+            }, _diff(memTableDef, dbTableDef, 'add', true, function (memIdx, dbIdx) {
+                return !dbIdx;
+            }, track)));
+            _changes[tableName] = _changes[tableName] || {};
+
+            _.map(_.keys(track), function(key){
+                _changes[tableName][key] = _changes[tableName][key] || [];
+                _changes[tableName][key].push.apply(_changes[tableName][key], track[key]);
+            });
+
+            function _diff(masterTblSchema, shadowTblSchema, opr, addMissingTable, addPredicate, diffs) {
+
+                if (!!masterTblSchema && !!masterTblSchema.indexes && masterTblSchema.indexes instanceof Array && !!shadowTblSchema) {
+                    (masterTblSchema.indexes || []).forEach(function (mstIdx) {
+                        var shdIdx = _.findWhere(shadowTblSchema.indexes, {name: mstIdx.name});
+
+                        if (addPredicate(mstIdx, shdIdx)) {
+                            diffs[opr] = diffs[opr] || [];
+                            diffs[opr].push(mstIdx);
+                        }
+                    });
+                } else if (addMissingTable) {
+                    diffs[opr] = diffs[opr] || [];
+                    diffs[opr].push.apply(diffs[opr], masterTblSchema.indexes);
+                }
+                return diffs;
             }
         }
 
-        function getPropsRecursive(template, map) {
-            map = map || {};
-            _.map(template.getProperties(), function (val, prop) {
-                map[prop] = val
-            });
-            template = template.__children__;
-            template.forEach(function (template) {
-                getPropsRecursive(template, map);
-            });
-            return map;
+        var generateChanges = function (localtemplate, value) {
+            return _.reduce(localtemplate.__children__, function (curr, o) {
+                return Promise.resolve()
+                    .then(loadTableDef.bind(this, _dbschema, o.__schema__, o.__name__))
+                    .spread(diffTable)
+                    .then(generateChanges.bind(this, o))
+                    .catch(function (e) {
+                        throw e;
+                    })
+            }, {});
         }
+
+        var getFilteredTarget = function(src, target){
+            return _.filter(target, function(o, filterkey){
+                var currName = _.reduce(o.def.columns, function (name, col) {
+                    return name + '_' + col;
+                }, 'idx_' + tableName);
+                return !_.find(src, function(cached){
+                    var cachedName = _.reduce(cached.def.columns, function (name, col) {
+                        return name + '_' + col;
+                    }, 'idx_' + tableName);
+                    console.log(cachedName, currName);
+                    return (cachedName === currName)
+
+                })
+            });
+        }
+
+        var mergeChanges = function() {
+            var dbChanges =   {add: [], change: [], delete: []};
+            _.map(dbChanges, function(object, key){
+                _.each(_changes, function(change){
+                    var filtered = getFilteredTarget(dbChanges[key], change[key])
+                    dbChanges[key].push.apply(dbChanges[key], filtered);
+                })
+            })
+
+            return dbChanges;
+        }
+
+        var applyTableChanges = function(dbChanges) {
+            function syncIndexesForHierarchy (operation, diffs, table) {
+                _.map(diffs[operation], (function (object, key) {
+                    var type = object.def.type;
+                    var columns = object.def.columns;
+                    if (type !== 'unique' && type !== 'index')
+                        throw new Error('index type can be only "unique" or "index"');
+
+                    var name = _.reduce(object.def.columns, function (name, col) {
+                        return name + '_' + col;
+                    }, 'idx_' + tableName);
+
+                    //var name = 'idx_' + tableName + '_' + object.name;
+                    if (operation === 'add') {
+                        console.log('adding %s \n', name )
+                        table[type](columns, name);
+                    }
+                    else if (operation === 'delete') {
+                        console.log('dels ', name )
+                        type= type.replace(/index/, 'Index');
+                        type = type.replace(/unique/, 'Unique')
+                        table['drop' + type]([], name);
+                    }
+                    else
+                        table[type](columns, name);
+
+                }).bind(this));
+            };
+
+            return knex.schema.table(tableName, function(table) {
+                _.map(Object.getOwnPropertyNames(dbChanges), function (key) {
+                    return syncIndexesForHierarchy.call(this, key, dbChanges, table);
+                }.bind(this));
+            })
+        }
+        var isSchemaChanged = function(object) {
+            return (object.add.length || object.change.length || object.delete.length)
+        }
+
+        var makeSchemaUpdates = function () {
+            var chgFound = _.reduce(_changes, function (curr, change) {
+                return curr || !!isSchemaChanged(change);
+            }, false);
+
+            if (!chgFound) return;
+            return knex(schemaTable)
+                .orderBy('sequence_id', 'desc')
+                .limit(1).then(function (record) {
+                    if (!record[0]) {
+                        return knex(schemaTable).insert({
+                            sequence_id: 1,
+                            schema: JSON.stringify(_templateSchema)
+                        });
+                    }
+                    else {
+                        _.map(_templateSchema, function (o, key) {
+                            _dbschema[key] = o;
+                        });
+                        return knex(schemaTable).insert({
+                            sequence_id: ++record[0].sequence_id,
+                            schema: JSON.stringify(_dbschema)
+                        });
+                    }
+                })
+        }
+
+        return Promise.resolve()
+            .then(loadSchema.bind(this, tableName))
+            .spread(loadTableDef)
+            .spread(diffTable)
+            .then(generateChanges.bind(this, template))
+            .then(mergeChanges)
+            .then(applyTableChanges)
+            .then(makeSchemaUpdates)
+            .catch(function(e) {
+                throw e;
+            })
+    };
+
+
+
+    function iscompatible(persistortype, pgtype) {
+        switch (persistortype) {
+            case 'String':
+            case 'Object':
+            case 'Array':
+                return pgtype.indexOf('text') > -1;
+            case 'Number':
+                return pgtype.indexOf('double precision') > -1;
+            case 'Boolean':
+                return pgtype.indexOf('bool') > -1;
+            case 'Date':
+                return pgtype.indexOf('timestamp') > -1;
+            default:
+                return pgtype.indexOf('text') > -1; // Typed objects have no name
+        }
+    }
+
+    function getPropsRecursive(template, map) {
+        map = map || {};
+        _.map(template.getProperties(), function (val, prop) {
+            map[prop] = val
+        });
+        template = template.__children__;
+        template.forEach(function (template) {
+            getPropsRecursive(template, map);
+        });
+        return map;
     }
 
     PersistObjectTemplate.persistTouchKnex = function(obj, txn) {
@@ -566,12 +657,18 @@ module.exports = function (PersistObjectTemplate) {
             }.bind(this))
     }
 
+    PersistObjectTemplate.createKnexTable = function (template, collection) {
+        var collection = collection || template.__table__;
+        var tableName = this.dealias(collection);
+        return PersistObjectTemplate._createKnexTable(template, collection)
+            .then(synchronizeIndexes.bind(this, tableName, template))
+    }
     /**
      * Create a table based on the schema definitions, will consider even indexes creation.
      * @param template
      * @returns {*}
      */
-    PersistObjectTemplate.createKnexTable = function (template, collection) {
+    PersistObjectTemplate._createKnexTable = function (template, collection) {
         var collection = collection || template.__table__;
         (function (){
             while(template.__parent__)
@@ -583,30 +680,6 @@ module.exports = function (PersistObjectTemplate) {
         var tableName = this.dealias(collection);
         var _cacheIndex = [];
         return knex.schema.createTable(tableName, createColumns.bind(this));
-        function setIndex(table, index) {
-            if (index.def) {
-                if (index.def.type !== 'unique' && index.def.type !== 'index')
-                    throw new Error('index type can be only "unique" or "index"');
-                var name = _.reduce(index.def.columns, function (name, col) {
-                    return name + '_' + col;
-                }, 'idx_' + tableName);
-                if (!_.contains(_cacheIndex, name)) {
-                    if (this._schemacache)
-                        this._schemacache[name] = true;
-                    _cacheIndex.push(name);
-                    table[index.def.type](index.def.columns, name);
-                }
-            }
-        }
-        function createIndexes(table, schema) {
-            if (!schema) return;
-            if (schema.indexes) {
-                schema.indexes.forEach(function (index) {
-                        setIndex.call(this, table, index);
-                    }.bind(this)
-                )
-            }
-        }
 
         function createColumns(table) {
             table.string('_id').primary();
@@ -641,7 +714,6 @@ module.exports = function (PersistObjectTemplate) {
                         columnMap[prop] = true;
                     }
                 }
-                createIndexes.call(this, table, schema);
             }
 
             function recursiveColumnMap(childTemplate) {

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -42,7 +42,7 @@ module.exports = function (PersistObjectTemplate) {
             _.each(options.sort, function (value, key) {
                 if (value > 0)
                     ascending.push(tableName + "." + key);
-                elsegit 
+                else
                     descending.push(tableName + "." + key);
             });
             if (ascending.length)

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -341,8 +341,6 @@ module.exports = function (PersistObjectTemplate) {
             if (!callBack) return;
             if (typeof callBack !== 'function')
                 throw new Error('persistor can only notify the field changes through a callback');
-            console.log('field change verification')
-
             var fieldsChanged = _.keys(_newFields).join();
 
             callBack('Following fields are being added to ' + table + ' table: \n    ' + fieldsChanged);
@@ -447,12 +445,12 @@ module.exports = function (PersistObjectTemplate) {
                     response = JSON.parse(record[0][schemaField]);
                 }
                 _dbschema = response;
-                return [response, schema, tableName];
+                return [response, schema, template.__name__];
             })
         }
 
         var loadTableDef = function(dbschema, schema, tableName) {
-            _templateSchema[tableName] = schema
+            _templateSchema[tableName] = schema;
             if (!dbschema[tableName])
                 dbschema[tableName] = {};
             return [dbschema[tableName], schema, tableName];
@@ -514,9 +512,7 @@ module.exports = function (PersistObjectTemplate) {
                     var cachedName = _.reduce(cached.def.columns, function (name, col) {
                         return name + '_' + col;
                     }, 'idx_' + tableName);
-                    console.log(cachedName, currName);
                     return (cachedName === currName)
-
                 })
             });
         }
@@ -547,11 +543,9 @@ module.exports = function (PersistObjectTemplate) {
 
                     //var name = 'idx_' + tableName + '_' + object.name;
                     if (operation === 'add') {
-                        console.log('adding %s \n', name )
                         table[type](columns, name);
                     }
                     else if (operation === 'delete') {
-                        console.log('dels ', name )
                         type= type.replace(/index/, 'Index');
                         type = type.replace(/unique/, 'Unique')
                         table['drop' + type]([], name);
@@ -562,12 +556,16 @@ module.exports = function (PersistObjectTemplate) {
                 }).bind(this));
             };
 
-            return knex.schema.table(tableName, function(table) {
-                _.map(Object.getOwnPropertyNames(dbChanges), function (key) {
-                    return syncIndexesForHierarchy.call(this, key, dbChanges, table);
-                }.bind(this));
+
+            return knex.transaction(function (trx) {
+                return trx.schema.table(tableName, function (table) {
+                    _.map(Object.getOwnPropertyNames(dbChanges), function (key) {
+                        return syncIndexesForHierarchy.call(this, key, dbChanges, table);
+                    }.bind(this));
+                })
             })
         }
+
         var isSchemaChanged = function(object) {
             return (object.add.length || object.change.length || object.delete.length)
         }

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -1,0 +1,389 @@
+var chai = require("chai");
+var expect = require('chai').expect;
+
+var chaiAsPromised = require("chai-as-promised");
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+var Q = require("q");
+var _ = require("underscore");
+var ObjectTemplate = require('supertype');
+var PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);
+var knex = require("knex");
+
+
+var Employee = PersistObjectTemplate.create("Employee", {
+    id: {type: Number},
+    name: {type: String, value: "Test Employee"},
+    newField: {type: String, value: "Test Employee", customField: "customValue"},
+    init: function (id, name) {
+        this.id = id;
+        this.name = name;
+    }
+})
+
+
+Manager = Employee.extend("Manager", {
+    init: function () {
+        this.id = 12312;
+        this.name = "Manager";
+        Employee.call(this);
+    },
+    dob: {type: Date, value: new Date()}
+});
+
+
+Executive = Manager.extend("Executive", {
+    init: function () {
+        this.id = 12312;
+        this.name = "Manager";
+        Employee.call(this);
+    },
+    execRole: {type: String, value: ''}
+});
+
+BoolTable = PersistObjectTemplate.create("BoolTable", {
+    boolField: {type: Boolean}
+});
+
+DateTable = PersistObjectTemplate.create("DateTable", {
+    dateField: {type: Date}
+});
+
+var ChangeFieldTypeTable = PersistObjectTemplate.create("ChangeFieldTypeTable", {
+    id: {type: Number},
+    name: {type: String, value: "Test Employee"},
+    init: function (id, name) {
+        this.id = id;
+        this.name = name;
+    }
+})
+
+var SingleIndexTable = PersistObjectTemplate.create("SingleIndexTable", {
+    id: {type: Number},
+    name: {type: String, value: "Name"},
+    init: function (id, name) {
+        this.id = id;
+        this.name = name;
+    }
+})
+
+
+var MultipleIndexTable = PersistObjectTemplate.create("MultipleIndexTable", {
+    id: {type: Number},
+    name: {type: String, value: "Name"},
+    init: function (id, name) {
+        this.id = id;
+        this.name = name;
+    }
+})
+
+var ChangeFieldTypeTable = PersistObjectTemplate.create("ChangeFieldTypeTable", {
+    id: {type: String},
+    name: {type: String, value: "Test Employee"},
+    init: function (id, name) {
+        this.id = id;
+        this.name = name;
+    }
+});
+
+var IndexSyncTable = PersistObjectTemplate.create('IndexSyncTable', {
+    id: {type: Number},
+    name: {type: String, value: "Test Employee"}
+})
+
+var Parent = PersistObjectTemplate.create("Parent", {
+    first: {type: String},
+    last: {type: String}
+});
+
+var ExtendParent = Parent.extend("ExtendParent", {
+    extend: {type: String}
+});
+
+var obj1 = new Employee(100, 'temp employee');
+var obj2 = new Employee(000, 'contractor');
+
+var Q = require('Q');
+var db;
+var schema = {
+    Employee: {
+        documentOf: "pg/Employee",
+        indexes: [{
+            name: "fst_index",
+            def: {
+                columns: ["name"],
+                type: "unique"
+            }
+        },
+            {
+                name: "new_index",
+                def: {
+                    columns: ["id"],
+                    type: "unique"
+                }
+            }]
+    },
+    Manager: {
+        documentOf: "pg/Manager",
+        indexes: [{
+            name: "single_index",
+            def: {
+                columns: ["name"],
+                type: "unique"
+            }
+        }]
+    },
+    Executive: {
+    documentOf: "pg/Manager",
+        indexes: [{
+        name: "exec_index",
+        def: {
+            columns: ["execRole"],
+            type: "unique"
+        }
+    }]
+},
+    Parent: {
+        documentOf:"pg/ParentExtendTest"
+    },
+    BoolTable: {
+        documentOf: "pg/BoolTable"
+    },
+    DateTable: {
+        documentOf: "pg/DateTable"
+    },
+    ChangeFieldTypeTable: {
+        documentOf: "pg/ChangeFieldTypeTable"
+    },
+    SingleIndexTable: {
+        documentOf: "pg/SingleIndexTable",
+        indexes: [{
+            name: "single_index",
+            def: {
+                columns: ["id", "name"],
+                type: "unique"
+            }
+        }]
+    },
+    MultipleIndexTable: {
+        documentOf: "pg/MultipleIndexTable",
+        indexes: [
+            {
+                name: "fst_index",
+                def: {
+                    columns: ["name"],
+                    type: "index"
+                }
+            },
+            {
+                name: "scd_index",
+                def: {
+                    columns: ["name", "id"],
+                    type: "index"
+                }
+            }]
+    },
+    IndexSyncTable: {
+        documentOf: "pg/IndexSyncTable",
+        indexes: [
+            {
+                name: "Fst_Index",
+                def: {
+                    columns: ["name"],
+                    type: "index"
+                }
+            }
+        ]
+    }
+}
+
+
+describe('index synchronization checks', function () {
+    var knex = require('knex')({
+        client: 'pg',
+        connection: {
+            host: '127.0.0.1',
+            database: 'persistor_banking',
+            user: 'nodejs',
+            password: 'nodejs'
+        }
+    });
+    var schemaTable = 'haven_schema1';
+    var checkKeyExistsInSchema = function(key){
+        return knex('haven_schema1')
+            .select('schema')
+            .orderBy('sequence_id', 'desc')
+            .limit(1)
+            .then(function (records) {
+                if (!records[0]) return false;
+                var pattern = new RegExp(key);
+                return !!records[0].schema.match(pattern);
+            })
+    };
+    var getIndexes = function(key){
+        return knex('haven_schema1')
+            .select('schema')
+            .orderBy('sequence_id', 'desc')
+            .limit(1)
+            .then(function (records) {
+                if (!records[0]) return [];
+                return JSON.parse(records[0].schema)[key].indexes;
+            })
+    };
+
+    before('arrange', function (done) {
+        (function () {
+            var db = require('knex')({
+                client: 'pg',
+                connection: {
+                    host: '127.0.0.1',
+                    database: 'persistor_banking',
+                    user: 'nodejs',
+                    password: 'nodejs'
+
+                }
+            });
+            PersistObjectTemplate.setDB(db, PersistObjectTemplate.DB_Knex, 'pg');
+            PersistObjectTemplate.setSchema(schema);
+            PersistObjectTemplate.performInjections(); // Normally done by getTemplates
+
+        })();
+        return Q.all([
+            knex.schema.dropTableIfExists('notificationCheck'),
+            PersistObjectTemplate.dropKnexTable(Employee),
+            PersistObjectTemplate.dropKnexTable(Manager),
+            PersistObjectTemplate.dropKnexTable(BoolTable),
+            PersistObjectTemplate.dropKnexTable(DateTable),
+            PersistObjectTemplate.dropKnexTable(SingleIndexTable),
+            PersistObjectTemplate.dropKnexTable(IndexSyncTable),
+            PersistObjectTemplate.dropKnexTable(MultipleIndexTable),
+            PersistObjectTemplate.dropKnexTable(Parent),
+            knex('haven_schema1').del(),
+            knex.schema.hasTable('IndexSyncTable').then(function(exists){
+                if (exists) knex.schema.dropTable('IndexSyncTable');
+            })
+        ]).should.notify(done);
+    });
+
+
+    it('synchronize the table without defining the indexes and make sure that the process does not make any entries to the schema table', function () {
+        //sync table
+        return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(ExtendParent).then(function(){
+            return checkKeyExistsInSchema('ExtendParent').should.eventually.equal(false);
+        })
+    });
+
+    it('synchronize the index definition and check if the index exists on the table by dropping the index', function () {
+        return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.have.property('command').that.match(/INSERT/);
+    });
+
+    it('calling synchronizeKnexTableFromTemplate without any changes to the schema definitions..', function () {
+        return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.be.fulfilled;
+    })
+
+    it('synchronize the index definition for a new table and leave it in the schema table..', function () {
+        return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(MultipleIndexTable).then(function(){
+            return checkKeyExistsInSchema('MultipleIndexTable').should.eventually.equal(true);
+        })
+    });
+
+    it('remove the existing index definition, system should delete the index', function () {
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
+            schema.IndexSyncTable.indexes = [];
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
+                return getIndexes('IndexSyncTable').should.eventually.have.length(0);
+            })
+        });
+    });
+
+    it('adding an index should upddate the table again..', function () {
+        schema.IndexSyncTable.indexes = [
+            {
+                name: "Fst_Index",
+                def: {
+                    columns: ["name"],
+                    type: "index"
+                }
+            }
+        ];
+
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
+            return getIndexes('IndexSyncTable').should.eventually.have.length(1);
+        });
+    });
+
+
+    it('adding an index should upddate the table again..', function () {
+        schema.IndexSyncTable.indexes = [
+            {
+                name: "Fst_Index",
+                def: {
+                    columns: ["name"],
+                    type: "index"
+                }
+            },
+            {
+                name: "Scd_Index",
+                def: {
+                    columns: ["id"],
+                    type: "index"
+                }
+            }
+        ];
+
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
+            return getIndexes('IndexSyncTable').should.eventually.have.length(2);
+        });
+    });
+
+    it('adding a new field and verifying the notification', function () {
+        function fieldsNotify(fields){
+            console.log(fields);
+        };
+
+
+        schema.notificationCheck = {};
+        schema.notificationCheck.documentOf = "pg/notificationCheck";
+        var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
+            id: {type: String},
+            name: {type: String, value: "PrimaryIndex"},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        })
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function (result) {
+            var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
+                id: {type: String},
+                name: {type: String, value: "PrimaryIndex"},
+                newField: {type: String, value: "PrimaryIndex"},
+                init: function (id, name) {
+                    this.id = id;
+                    this.name = name;
+                }
+            });
+
+            PersistObjectTemplate._verifySchema();
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function () {
+
+            });
+        });
+    });
+
+    it("creating parent and child and synchronize the parent to check the child table indexes", function (done) {
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (result) {
+            return Q.all([getIndexes('Employee').should.eventually.have.length(2),
+                getIndexes('Manager').should.eventually.have.length(1),
+                getIndexes('Executive').should.eventually.have.length(1)]).should.notify(done);
+
+        });
+    });
+
+    
+
+})

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -111,7 +111,7 @@ var Q = require('Q');
 var db;
 var schema = {
     Employee: {
-        documentOf: "pg/Employee",
+        documentOf: "pg/employee",
         indexes: [{
             name: "fst_index",
             def: {
@@ -160,7 +160,7 @@ var schema = {
         documentOf: "pg/ChangeFieldTypeTable"
     },
     SingleIndexTable: {
-        documentOf: "pg/SingleIndexTable",
+        documentOf: "pg/singleIndexTable",
         indexes: [{
             name: "single_index",
             def: {
@@ -255,7 +255,7 @@ describe('index synchronization checks', function () {
         return Q.all([
             knex.schema.dropTableIfExists('notificationCheck'),
             PersistObjectTemplate.dropKnexTable(Employee),
-            PersistObjectTemplate.dropKnexTable(Manager),
+           // PersistObjectTemplate.dropKnexTable(Manager),
             PersistObjectTemplate.dropKnexTable(BoolTable),
             PersistObjectTemplate.dropKnexTable(DateTable),
             PersistObjectTemplate.dropKnexTable(SingleIndexTable),
@@ -276,21 +276,21 @@ describe('index synchronization checks', function () {
             return checkKeyExistsInSchema('ExtendParent').should.eventually.equal(false);
         })
     });
-
+    
     it('synchronize the index definition and check if the index exists on the table by dropping the index', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.have.property('command').that.match(/INSERT/);
     });
-
+    
     it('calling synchronizeKnexTableFromTemplate without any changes to the schema definitions..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.be.fulfilled;
     })
-
+    
     it('synchronize the index definition for a new table and leave it in the schema table..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(MultipleIndexTable).then(function(){
             return checkKeyExistsInSchema('MultipleIndexTable').should.eventually.equal(true);
         })
     });
-
+    
     it('remove the existing index definition, system should delete the index', function () {
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             schema.IndexSyncTable.indexes = [];
@@ -299,7 +299,7 @@ describe('index synchronization checks', function () {
             })
         });
     });
-
+    
     it('adding an index should upddate the table again..', function () {
         schema.IndexSyncTable.indexes = [
             {
@@ -310,13 +310,13 @@ describe('index synchronization checks', function () {
                 }
             }
         ];
-
+    
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             return getIndexes('IndexSyncTable').should.eventually.have.length(1);
         });
     });
-
-
+    
+    
     it('adding an index should upddate the table again..', function () {
         schema.IndexSyncTable.indexes = [
             {
@@ -334,18 +334,18 @@ describe('index synchronization checks', function () {
                 }
             }
         ];
-
+    
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             return getIndexes('IndexSyncTable').should.eventually.have.length(2);
         });
     });
-
+    
     it('adding a new field and verifying the notification', function () {
         function fieldsNotify(fields){
             console.log(fields);
         };
-
-
+    
+    
         schema.notificationCheck = {};
         schema.notificationCheck.documentOf = "pg/notificationCheck";
         var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
@@ -367,10 +367,10 @@ describe('index synchronization checks', function () {
                     this.name = name;
                 }
             });
-
+    
             PersistObjectTemplate._verifySchema();
             return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function () {
-
+    
             });
         });
     });

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -105,7 +105,7 @@ var Q = require('Q');
 var db;
 var schema = {
     Employee: {
-        documentOf: "pg/Employee"
+        documentOf: "pg/employee"
     },
     Manager: {
         documentOf: "pg/Manager",
@@ -282,7 +282,7 @@ describe('index synchronization checks', function () {
 
 
             return Q.all(
-                [   knex.schema.dropTableIfExists('Employee'),
+                [   knex.schema.dropTableIfExists('employee'),
                     knex.schema.dropTableIfExists('BoolTable'),
                     knex.schema.dropTableIfExists('ChangeFieldTypeTable'),
                     knex.schema.dropTableIfExists('DateTable'),

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -108,7 +108,14 @@ var schema = {
         documentOf: "pg/Employee"
     },
     Manager: {
-        documentOf: "pg/Manager"
+        documentOf: "pg/Manager",
+        indexes: [{
+            name: "single_index",
+            def: {
+                columns: ["dob", "name"],
+                type: "unique"
+            }
+        }]
     },
     Parent: {
         documentOf:"pg/ParentExtendTest"
@@ -159,49 +166,13 @@ var schema = {
                     columns: ["name"],
                     type: "index"
                 }
-            },
-            {
-                name: "Scd_Index",
-                def: {
-                    columns: ["name"],
-                    type: "index"
-                }
-            },
-            {
-                name: "third_index",
-                def: {
-                    columns: ["name"],
-                    type: "index"
-                }
             }
         ]
     }
 }
 
 
-function clearCollection(template) {
-    var collectionName = template.__collection__.match(/\//) ? template.__collection__ : 'mongo/' + template.__collection__;
-    console.log("Clearing " + collectionName);
-    if (collectionName.match(/mongo\/(.*)/)) {
-        collectionName = RegExp.$1;
-        return Q.ninvoke(db, "collection", collectionName).then(function (collection) {
-            return Q.ninvoke(collection, "remove", {}, {w: 1}).then(function () {
-                return Q.ninvoke(collection, "count")
-            });
-        });
-    }
-    else if (collectionName.match(/pg\/(.*)/)) {
-        collectionName = RegExp.$1;
-        return PersistObjectTemplate.dropKnexTable(template)
-            .then(function () {
-                return PersistObjectTemplate.createKnexTable(template).then(function () {
-                    return 0
-                });
-            });
-    } else
-        throw "Invalid collection name " + collectionName;
 
-}
 
 describe('index synchronization checks', function () {
     before('arrange', function (done) {
@@ -211,8 +182,8 @@ describe('index synchronization checks', function () {
                 connection: {
                     host: '127.0.0.1',
                     database: 'persistor_banking',
-                    user: 'postgres',
-                    password: 'postgres'
+                    user: 'nodejs',
+                    password: 'nodejs'
 
                 }
             });
@@ -221,13 +192,16 @@ describe('index synchronization checks', function () {
             PersistObjectTemplate.performInjections(); // Normally done by getTemplates
         })();
         return Q.all([
+            knex.schema.dropTableIfExists('NewTable'),
             PersistObjectTemplate.dropKnexTable(Employee),
             PersistObjectTemplate.dropKnexTable(Manager),
             PersistObjectTemplate.dropKnexTable(BoolTable),
             PersistObjectTemplate.dropKnexTable(DateTable),
             PersistObjectTemplate.dropKnexTable(SingleIndexTable),
             PersistObjectTemplate.dropKnexTable(MultipleIndexTable),
-            PersistObjectTemplate.dropKnexTable(Parent)
+            PersistObjectTemplate.dropKnexTable(Parent),
+            knex('haven_schema1').del(),
+
         ]).should.notify(done);
     });
 
@@ -246,8 +220,8 @@ describe('index synchronization checks', function () {
             connection: {
                 host: '127.0.0.1',
                 database: 'persistor_banking',
-                user: 'postgres',
-                password: 'postgres'
+                user: 'nodejs',
+                password: 'nodejs'
 
             }
         });
@@ -280,7 +254,7 @@ describe('index synchronization checks', function () {
     });
 
     it("create a table with an index", function () {
-        return PersistObjectTemplate.createKnexTable(SingleIndexTable).then(function () {
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(SingleIndexTable).then(function () {
             return PersistObjectTemplate.checkForKnexTable(SingleIndexTable).should.eventually.equal(true);
         })
     });
@@ -291,8 +265,8 @@ describe('index synchronization checks', function () {
         connection: {
             host: '127.0.0.1',
             database: 'persistor_banking',
-            user: 'postgres',
-            password: 'postgres'
+            user: 'nodejs',
+            password: 'nodejs'
         }
     });
 
@@ -306,25 +280,10 @@ describe('index synchronization checks', function () {
              Step3: set the schema version table without any indexes...
              */
 
-            var resetdata = (function () {
 
-                return knex('haven_schema1')
-                    .select('sequence_id')
-                    .orderBy('sequence_id', 'desc')
-                    .limit(1)
-                    .then(function (v) {
-                        var sc = JSON.parse(JSON.stringify(schema));
-                        if (sc.IndexSyncTable && sc.IndexSyncTable.indexes)
-                            delete sc.IndexSyncTable.indexes;
-
-                        return knex('haven_schema1').insert({
-                            sequence_id: ++v[0].sequence_id,
-                            schema: JSON.stringify(sc)
-                        })
-                    })
-            })();
             return Q.all(
-                [knex.schema.dropTableIfExists('BoolTable'),
+                [   knex.schema.dropTableIfExists('Employee'),
+                    knex.schema.dropTableIfExists('BoolTable'),
                     knex.schema.dropTableIfExists('ChangeFieldTypeTable'),
                     knex.schema.dropTableIfExists('DateTable'),
                     knex.schema.dropTableIfExists('CreatingTable'),
@@ -335,14 +294,10 @@ describe('index synchronization checks', function () {
                             table.text('name')
                         })
                     }),
-                  resetdata
+                    knex('haven_schema1').del()
                 ]).should.notify(done);
         });
 
-
-        it('identify schema changes and update the schema version table', function () {
-            return PersistObjectTemplate.saveSchema('pg').should.eventually.have.property("command");
-        });
 
 
         it('synchronize the index definition and check if the index exists on the table by dropping the index', function () {
@@ -373,11 +328,9 @@ describe('index synchronization checks', function () {
             schema.Employee.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["name"],"type": "unique"}}]');
             schema.Manager.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["name"],"type": "unique"}}]');
 
-            return PersistObjectTemplate.saveSchema('pg').should.eventually.have.property('command').then(function() {
                 return PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (status) {
                     return PersistObjectTemplate.checkForKnexTable(Employee).should.eventually.equal(true);
                 })
-            })
 
         })
 
@@ -401,24 +354,6 @@ describe('index synchronization checks', function () {
                 })
             })
         })
-
-
-
-        it('remove an index from the schema and synchronize the schema definitions', function () {
-            delete schema.CreatingTable
-            return Q(PersistObjectTemplate._verifySchema()).then(function() {
-                return PersistObjectTemplate.saveSchema('pg').then(function () {
-                    return knex('haven_schema1')
-                        .select('schema')
-                        .orderBy('sequence_id', 'desc')
-                        .limit(1)
-                        .then(function (records) {
-                            return Q(records[0].schema).should.eventually.not.contain('CreatingTable');
-                        });
-                });
-            })
-
-        });
     });
 
     it('Add a new index and call createKnexTable to create the table and the corresponding indexes', function () {
@@ -435,14 +370,23 @@ describe('index synchronization checks', function () {
         schema.newTable.indexes = (JSON.parse('[{"name": "scd_index","def": {"columns": ["id"],"type": "primary"}}]'));
 
         PersistObjectTemplate._verifySchema();
-        return PersistObjectTemplate.createKnexTable(newTable).should.eventually.be.rejectedWith(Error, 'index type can be only \"unique\" or \"index\"');
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.be.rejectedWith(Error, 'index type can be only \"unique\" or \"index\"');
     });
 
     it('add a new table definition to the schema and try to synchronize', function () {
         schema.newTable = {};
         schema.newTable.documentOf = "pg/NewTable";
+        var newTable = PersistObjectTemplate.create("newTable", {
+            id: {type: String},
+            name: {type: String, value: "PrimaryIndex"},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        })
         schema.newTable.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["id", "name"],"type": "unique"}}]');
-        return PersistObjectTemplate.saveSchema('pg').then(function () {
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).then(function () {
             return knex('haven_schema1')
                 .select('schema')
                 .orderBy('sequence_id', 'desc')
@@ -478,16 +422,16 @@ describe('index synchronization checks', function () {
 
     });
 
-    //it('save bool type and check the return value and type', function () {
-    //    var boolData = new BoolTable(true);
-    //    return boolData.persistSave().should.eventually.equal(boolData._id).then(function () {
-    //        var fetchbool = new Boolean();
-    //        //return BoolTable.getFromPersistWithQuery({'boolField': true}).then(function(record){
-    //        //   // console.dir(record);
-    //        //})
-    //    })
-    //})
-    //
+    it('save bool type and check the return value and type', function () {
+       var boolData = new BoolTable(true);
+       return boolData.persistSave().should.eventually.equal(boolData._id).then(function () {
+           var fetchbool = new Boolean();
+           //return BoolTable.getFromPersistWithQuery({'boolField': true}).then(function(record){
+           //   // console.dir(record);
+           //})
+       })
+    })
+
     it("save employee individually...", function (done) {
         var validEmployee = new Employee('1111', 'New Employee');
         try {
@@ -508,15 +452,6 @@ describe('index synchronization checks', function () {
         return invalidEmployee.persistSave().should.be.rejectedWith(Error, 'insert into');
     });
 
-    it("load the POJO from DB", function() {
 
-      //  var emp = PersistObjectTemplate.getPOJOsFromKnexQuery(Employee, "{id: 100}")
-        //console.dir(emp);
-       // var emp1;
-       // return Employee.getFromPersistWithQuery({id: 100}).then (function (emp) {
-       //     console.dir(emp);
-       // });
-
-    })
 })
 


### PR DESCRIPTION
Sam,
I've made table synchronization changes and also merged your ## 1.0.0-beta-5 changes to knex/db.js file. I've added a few more test cases to cover broader scenarios.

High-level changes are as follows:
1. saveSchema function has been removed as we track the table level changes as part of synchronizeKnexTableFromTemplate call.
2. users can provide a callback to synchronizeKnexTableFromTemplate to get the table and field level changes as part of the call.
3. all index changes are part of a transaction to keep the status of the indexes on a table in sync with the schema definition of the table.

Please note that I revamped the complete code as our previous approach is totally different from the current approach, but I've tested my level best even on haven codebase.



Thanks,
Ravi