### PR TITLE
all index names must be in lower-case

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -529,7 +529,7 @@ module.exports = function (PersistObjectTemplate) {
                     var cachedName = _.reduce(cached.def.columns, function (name, col) {
                         return name + '_' + col;
                     }, 'idx_' + tableName);
-                    return (cachedName === currName)
+                    return (cachedName.toLowerCase() === currName.toLowerCase())
                 })
             });
         }
@@ -558,7 +558,7 @@ module.exports = function (PersistObjectTemplate) {
                         return name + '_' + col;
                     }, 'idx_' + tableName);
 
-                    //var name = 'idx_' + tableName + '_' + object.name;
+                    name = name.toLowerCase();
                     if (operation === 'add') {
                         table[type](columns, name);
                     }

--- a/test/persist_polymorphic.js
+++ b/test/persist_polymorphic.js
@@ -572,7 +572,7 @@ describe('type mapping tests for parent/child relations', function () {
     it("Both parent and child index definitions are added to the parent table", function () {
         return PersistObjectTemplate.createKnexTable(Parent_Idx).then(function (status) {
             return knex.schema.table('Parent_Idx', function (table) {
-                        table.dropIndex([], 'Idx_parent_Idx_id_name');
+                        table.dropIndex([], 'idx_parent_idx_id_name');
                     }).should.eventually.have.property("command")
         });
     });
@@ -587,7 +587,7 @@ describe('type mapping tests for parent/child relations', function () {
     it("When trying to create child table, system should create the parent table and the corresonding indexes in the object graph must be added to the table", function () {
         return PersistObjectTemplate.createKnexTable(ChildToCreate1).then(function (status) {
             return knex.schema.table('ChildCreatesThisParent1', function (table) {
-                table.dropIndex([], 'Idx_ChildCreatesThisParent1_dob');
+                table.dropIndex([], 'idx_childcreatesthisparent1_dob');
             }).should.eventually.have.property("command")
         })
     });
@@ -599,7 +599,7 @@ describe('type mapping tests for parent/child relations', function () {
     it("Multilevel inheritance with indexes defined at different levels", function () {
         return PersistObjectTemplate.createKnexTable(ParentMulteLevelIndx1).then(function (status) {
             return knex.schema.table('ParentMulteLevelIndx1', function (table) {
-                table.dropIndex([], 'Idx_ParentMulteLevelIndx1_dob');
+                table.dropIndex([], 'idx_parentmultelevelindx1_dob');
             }).should.eventually.have.property("command")
         })
     });
@@ -613,15 +613,15 @@ describe('type mapping tests for parent/child relations', function () {
             return PersistObjectTemplate.checkForKnexTable(Scenario_2_ParentWithMultiChildAttheSameLevel).should.eventually.equal(true);
         })
     });
-
+    
     it("Multilevel inheritance with multiple children at the multiple levels", function () {
         return PersistObjectTemplate.createKnexTable(ParentWithMultiChildAttheSameLevelWithIndexes).then(function (status) {
             return PersistObjectTemplate.checkForKnexTable(ParentWithMultiChildAttheSameLevelWithIndexes).should.eventually.equal(true);
         })
     });
-
-
-
+    
+    
+    
     it("Adding a child with index to a parent and synchronize.", function () {
         childSynchronize = parentSynchronize.extend("childSynchronize", {
             init: function() {
@@ -631,13 +631,13 @@ describe('type mapping tests for parent/child relations', function () {
             },
             dob: {type: Date}
         })
-
+    
         schema.childSynchronize = {};
-
+    
         schema.childSynchronize.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["dob"],"type": "unique"}}]');
-
+    
         PersistObjectTemplate._verifySchema();
-
+    
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(childSynchronize).then(function (status) {
             return PersistObjectTemplate.checkForKnexTable(parentSynchronize).should.eventually.equal(true).then(function(){
                 schema.childSynchronize.indexes = JSON.parse('[{"name": "scd_index","def": {"columns": ["name"],"type": "unique"}}]');
@@ -645,7 +645,7 @@ describe('type mapping tests for parent/child relations', function () {
                    // return Q();
             })
         })
-
+    
     });
 })
 

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -266,21 +266,21 @@ describe('index synchronization checks', function () {
             return checkKeyExistsInSchema('ExtendParent').should.eventually.equal(false);
         })
     });
-    
+   
     it('synchronize the index definition and check if the index exists on the table by dropping the index', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.have.property('command').that.match(/INSERT/);
     });
-    
+   
     it('calling synchronizeKnexTableFromTemplate without any changes to the schema definitions..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.be.fulfilled;
     })
-    
+   
     it('synchronize the index definition for a new table and leave it in the schema table..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(MultipleIndexTable).then(function(){
             return checkKeyExistsInSchema('MultipleIndexTable').should.eventually.equal(true);
         })
     });
-    
+   
     it('remove the existing index definition, system should delete the index', function () {
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             schema.IndexSyncTable.indexes = [];
@@ -289,7 +289,7 @@ describe('index synchronization checks', function () {
             })
         });
     });
-    
+   
     it('adding an index should upddate the table again..', function () {
         schema.IndexSyncTable.indexes = [
             {
@@ -300,13 +300,13 @@ describe('index synchronization checks', function () {
                 }
             }
         ];
-    
+   
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             return getIndexes('IndexSyncTable').should.eventually.have.length(1);
         });
     });
-    
-    
+   
+   
     it('adding an index should upddate the table again..', function () {
         schema.IndexSyncTable.indexes = [
             {
@@ -324,18 +324,18 @@ describe('index synchronization checks', function () {
                 }
             }
         ];
-    
+   
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function (result) {
             return getIndexes('IndexSyncTable').should.eventually.have.length(2);
         });
     });
-    
+   
     it('adding a new field and verifying the notification', function () {
         function fieldsNotify(fields){
             console.log(fields);
         };
-    
-    
+   
+   
         schema.notificationCheck = {};
         schema.notificationCheck.documentOf = "pg/notificationCheck";
         var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
@@ -357,23 +357,23 @@ describe('index synchronization checks', function () {
                     this.name = name;
                 }
             });
-    
+   
             PersistObjectTemplate._verifySchema();
             return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function () {
-    
+   
             });
         });
     });
-    
+   
     it("creating parent and child and synchronize the parent to check the child table indexes", function (done) {
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (result) {
             return Q.all([getIndexes('Employee').should.eventually.have.length(2),
                 getIndexes('Manager').should.eventually.have.length(1),
                 getIndexes('Executive').should.eventually.have.length(1)]).should.notify(done);
-    
+   
         });
     });
 
-    
+   
 
 })

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -215,7 +215,6 @@ describe('index synchronization checks', function () {
 
 
     it("change to incompatible type and check for exception", function () {
-    
         return knex.schema.createTableIfNotExists('ChangeFieldTypeTable', function (table) {
             table.integer('id');
             table.text('name')
@@ -223,27 +222,27 @@ describe('index synchronization checks', function () {
             return PersistObjectTemplate.synchronizeKnexTableFromTemplate(ChangeFieldTypeTable).should.eventually.be.rejectedWith(Error);
         });
     });
-    
-    
+
+
     it("create a table for extended object", function () {
     return PersistObjectTemplate.createKnexTable(ExtendParent).then(function() {
             return PersistObjectTemplate.checkForKnexTable(Parent).should.eventually.equal(true);
         })
     });
-    
-    
+
+
     it("create a table with a boolean field", function () {
         return PersistObjectTemplate.createKnexTable(BoolTable).then(function (status) {
             return PersistObjectTemplate.checkForKnexColumnType(BoolTable, 'boolField').should.eventually.equal('boolean');
         })
     });
-    
+
     it("create a table with a date field", function () {
         return PersistObjectTemplate.createKnexTable(DateTable).then(function () {
             return PersistObjectTemplate.checkForKnexColumnType(DateTable, 'dateField').should.eventually.contains('timestamp');
         })
     });
-    
+
     it("create a table with an index", function () {
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(SingleIndexTable).then(function () {
             return PersistObjectTemplate.checkForKnexTable(SingleIndexTable).should.eventually.equal(true);
@@ -254,16 +253,12 @@ describe('index synchronization checks', function () {
 
 
     describe('synchronize the table with schema changes', function () {
-    
+
         before('arrange', function (done) {
-        
-        
             /*Step1: Drop if index test table exists..
              Step2: Create the table without indexes..
              Step3: set the schema version table without any indexes...
              */
-        
-        
             return Q.all(
                 [   knex.schema.dropTableIfExists('employee'),
                     knex.schema.dropTableIfExists('BoolTable'),
@@ -280,44 +275,43 @@ describe('index synchronization checks', function () {
                     knex('haven_schema1').del()
                 ]).should.notify(done);
         });
-        
-        
-        
+
+
+
         it('synchronize the index definition and check if the index exists on the table by dropping the index', function () {
-        
            return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).then(function () {
                     return knex.schema.table('IndexSyncTable', function (table) {
-                        table.dropIndex([], 'Idx_IndexSyncTable_name');
+                        table.dropIndex([], 'idx_indexsynctable_name');
                     }).should.eventually.have.property("command")
                 }
             );
         });
-        
+
         it("create a new type and synchronize the table.. ", function () {
             schema.CreateNewType = {};
             schema.CreateNewType.documentOf = "pg/CreateNewType";
             var CreateNewType = PersistObjectTemplate.create("CreateNewType", {
                 id: {type: String}
             })
-        
+
             PersistObjectTemplate._verifySchema();
             return PersistObjectTemplate.synchronizeKnexTableFromTemplate(CreateNewType).then(function (status) {
                 return PersistObjectTemplate.checkForKnexTable(CreateNewType).should.eventually.equal(true);
             })
         });
-        
-        
+
+
         it("use the same index names on multiple tables and create index to check the name generation process", function () {
             schema.Employee.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["name"],"type": "unique"}}]');
             schema.Manager.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["name"],"type": "unique"}}]');
-        
+
                 return PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (status) {
                     return PersistObjectTemplate.checkForKnexTable(Employee).should.eventually.equal(true);
                 })
-        
+
         })
-        
-        
+
+
         it('add a new type and check if the table creation is adding the index definition...', function(){
             schema.CreatingTable = {};
             schema.CreatingTable.documentOf = "pg/CreatingTable";
@@ -330,7 +324,7 @@ describe('index synchronization checks', function () {
                     this.name = name;
                 }
             })
-        
+
             return Q(PersistObjectTemplate._verifySchema()).then(function () {
                 return PersistObjectTemplate.createKnexTable(CreatingTable).then(function () {
                     return PersistObjectTemplate.checkForKnexTable(CreatingTable).should.eventually.equal(true);
@@ -351,11 +345,11 @@ describe('index synchronization checks', function () {
             }
         })
         schema.newTable.indexes = (JSON.parse('[{"name": "scd_index","def": {"columns": ["id"],"type": "primary"}}]'));
-    
+
         PersistObjectTemplate._verifySchema();
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.be.rejectedWith(Error, 'index type can be only \"unique\" or \"index\"');
     });
-    
+
     it('add a new table definition to the schema and try to synchronize', function () {
         schema.newTable = {};
         schema.newTable.documentOf = "pg/NewTable";
@@ -378,18 +372,18 @@ describe('index synchronization checks', function () {
                     return Q(records[0].schema);
                 })
         }).should.eventually.contain('NewTable');
-    
+
     });
-    
-    
+
+
     it("drop an index if exits", function () {
         return PersistObjectTemplate.DropIfKnexIndexExists(SingleIndexTable, "idx_singleindextable_id_name").should.eventually.have.property("command").that.match(/DROP|ALTER/);
     });
-    
+
     it("drop an index which does not exists to check the exception", function () {
         return PersistObjectTemplate.DropIfKnexIndexExists(SingleIndexTable, "notavailable").should.be.rejectedWith(Error);
     });
-    
+
     it("create a table with multiple indexes", function () {
         //don't like to check the result this way.. but I felt that using knex in the test cases is equally bad
         //and the knex responses are not clean, will check with Sam and make necessary changes..
@@ -397,24 +391,21 @@ describe('index synchronization checks', function () {
             return PersistObjectTemplate.checkForKnexTable(MultipleIndexTable).should.eventually.equal(true);
         })
     });
-    
-    
+
+
     it("save all employees in the cache...", function (done) {
         var ravi = new Employee(2, 'kumar');
         return PersistObjectTemplate.saveAll().should.eventually.equal(true).should.notify(done);
-    
+
     });
-    
+
     it('save bool type and check the return value and type', function () {
        var boolData = new BoolTable(true);
        return boolData.persistSave().should.eventually.equal(boolData._id).then(function () {
            var fetchbool = new Boolean();
-           //return BoolTable.getFromPersistWithQuery({'boolField': true}).then(function(record){
-           //   // console.dir(record);
-           //})
        })
     })
-    
+
     it("save employee individually...", function (done) {
         var validEmployee = new Employee('1111', 'New Employee');
         try {
@@ -429,7 +420,7 @@ describe('index synchronization checks', function () {
             done(e);
         }
     });
-    
+
     it("should throw exception for non numeric ids", function () {
         var invalidEmployee = new Employee('AAAA', 'Failed Employee');
         return invalidEmployee.persistSave().should.be.rejectedWith(Error, 'insert into');


### PR DESCRIPTION
Sam,
I've observed an issue if I run npm update. I'm not sure if knex has been modified or the latest changes in supertype are causing this. Index names are generated exactly in similar case provided in table name and field names. I've checked our current db and all of them are in lower-case. I changed the logic to create indexes in lower-case and use lower-case when comparing the current definitions with the previous definitions. 

Can you accept this pull request and let me know if this resolved the issue. Sorry for these many requests.

Thanks,
Ravi