### PR TITLE
Index synchronization fixes.

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -431,10 +431,10 @@ module.exports = function (PersistObjectTemplate) {
 
         var props = getPropsRecursive(template);
         var knex = this.getDB(this.getDBAlias(template.__table__)).connection
-        var schema = template.__schema__;
+        var schema = this._schema;
         var _newFields = {};
 
-        var _dbschema, _templateSchema = {};
+        var _dbschema;
         var _changes =  {};
         var schemaTable = 'haven_schema1';
         var schemaField = 'schema';
@@ -462,18 +462,19 @@ module.exports = function (PersistObjectTemplate) {
                     response = JSON.parse(record[0][schemaField]);
                 }
                 _dbschema = response;
-                return [response, schema, template.__name__];
+                return [response, template.__name__];
             })
         }
 
-        var loadTableDef = function(dbschema, schema, tableName) {
-            _templateSchema[tableName] = schema;
+        var loadTableDef = function(dbschema, tableName) {
             if (!dbschema[tableName])
                 dbschema[tableName] = {};
-            return [dbschema[tableName], schema, tableName];
+            return [dbschema, schema, tableName];
         }
 
-        var diffTable = function(dbTableDef, memTableDef, tableName){
+        var diffTable = function(dbschema, schema, tableName){
+            var dbTableDef = dbschema[tableName];
+            var memTableDef = schema[tableName]
             var track = {add: [], change: [], delete: []};
             _diff(dbTableDef, memTableDef, 'delete', false, function (dbIdx, memIdx) {
                 return !memIdx;
@@ -500,9 +501,9 @@ module.exports = function (PersistObjectTemplate) {
                             diffs[opr].push(mstIdx);
                         }
                     });
-                } else if (addMissingTable) {
+                } else if (addMissingTable && !!masterTblSchema && !!masterTblSchema.indexes) {
                     diffs[opr] = diffs[opr] || [];
-                    diffs[opr].push.apply(diffs[opr], masterTblSchema.indexes);
+                   diffs[opr].push.apply(diffs[opr], masterTblSchema.indexes);
                 }
                 return diffs;
             }
@@ -511,7 +512,7 @@ module.exports = function (PersistObjectTemplate) {
         var generateChanges = function (localtemplate, value) {
             return _.reduce(localtemplate.__children__, function (curr, o) {
                 return Promise.resolve()
-                    .then(loadTableDef.bind(this, _dbschema, o.__schema__, o.__name__))
+                    .then(loadTableDef.bind(this, _dbschema, o.__name__))
                     .spread(diffTable)
                     .then(generateChanges.bind(this, o))
                     .catch(function (e) {
@@ -593,25 +594,27 @@ module.exports = function (PersistObjectTemplate) {
             }, false);
 
             if (!chgFound) return;
+
             return knex(schemaTable)
                 .orderBy('sequence_id', 'desc')
                 .limit(1).then(function (record) {
+                    var response = {}, sequence_id;
                     if (!record[0]) {
-                        return knex(schemaTable).insert({
-                            sequence_id: 1,
-                            schema: JSON.stringify(_templateSchema)
-                        });
+                        sequence_id = 1;
                     }
                     else {
-                        _.map(_templateSchema, function (o, key) {
-                            _dbschema[key] = o;
-                        });
-                        return knex(schemaTable).insert({
-                            sequence_id: ++record[0].sequence_id,
-                            schema: JSON.stringify(_dbschema)
-                        });
+                        response = JSON.parse(record[0][schemaField]);
+                        sequence_id = ++record[0].sequence_id;
                     }
-                })
+                    _.each(_changes, function (o, chgKey) {
+                         response[chgKey] = schema[chgKey];
+                    });
+
+                    return knex(schemaTable).insert({
+                        sequence_id: sequence_id,
+                        schema: JSON.stringify(response)
+                    });
+            })
         }
 
         return Promise.resolve()

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -436,7 +436,7 @@ module.exports = function (PersistObjectTemplate) {
 
         var _dbschema;
         var _changes =  {};
-        var schemaTable = 'haven_schema1';
+        var schemaTable = 'index_schema_history';
         var schemaField = 'schema';
 
 

--- a/test/persist_polymorphic.js
+++ b/test/persist_polymorphic.js
@@ -559,7 +559,7 @@ describe('type mapping tests for parent/child relations', function () {
             PersistObjectTemplate.dropKnexTable(Scenario_2_ParentWithMultiChildAttheSameLevel),
             PersistObjectTemplate.dropKnexTable(ParentWithMultiChildAttheSameLevelWithIndexes),
             PersistObjectTemplate.dropKnexTable(parentSynchronize),
-            knex('haven_schema1').del()
+            knex('index_schema_history').del()
         ]).should.notify(done);;
     })
 

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -200,7 +200,7 @@ var schema = {
     }
 }
 
-
+var schemaTable = 'index_schema_history';
 describe('index synchronization checks', function () {
     var knex = require('knex')({
         client: 'pg',
@@ -211,9 +211,9 @@ describe('index synchronization checks', function () {
             password: 'postgres'
         }
     });
-    var schemaTable = 'haven_schema1';
+   
     var checkKeyExistsInSchema = function(key){
-        return knex('haven_schema1')
+        return knex(schemaTable)
             .select('schema')
             .orderBy('sequence_id', 'desc')
             .limit(1)
@@ -224,7 +224,7 @@ describe('index synchronization checks', function () {
             })
     };
     var getIndexes = function(key){
-        return knex('haven_schema1')
+        return knex(schemaTable)
             .select('schema')
             .orderBy('sequence_id', 'desc')
             .limit(1)
@@ -252,7 +252,7 @@ describe('index synchronization checks', function () {
             PersistObjectTemplate.dropKnexTable(IndexSyncTable),
             PersistObjectTemplate.dropKnexTable(MultipleIndexTable),
             PersistObjectTemplate.dropKnexTable(Parent),
-            knex('haven_schema1').del(),
+            knex(schemaTable).del(),
             knex.schema.hasTable('IndexSyncTable').then(function(exists){
                 if (exists) knex.schema.dropTable('IndexSyncTable');
             })

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -171,7 +171,7 @@ var schema = {
 }
 
 
-
+var schemaTable = 'index_schema_history';
 
 describe('index synchronization checks', function () {
     var knex = require('knex')({
@@ -200,7 +200,7 @@ describe('index synchronization checks', function () {
             PersistObjectTemplate.dropKnexTable(SingleIndexTable),
             PersistObjectTemplate.dropKnexTable(MultipleIndexTable),
             PersistObjectTemplate.dropKnexTable(Parent),
-            knex('haven_schema1').del(),
+            knex(schemaTable).del(),
 
         ]).should.notify(done);
     });
@@ -272,7 +272,7 @@ describe('index synchronization checks', function () {
                             table.text('name')
                         })
                     }),
-                    knex('haven_schema1').del()
+                    knex(schemaTable).del()
                 ]).should.notify(done);
         });
 
@@ -364,7 +364,7 @@ describe('index synchronization checks', function () {
         schema.newTable.indexes = JSON.parse('[{"name": "single_index","def": {"columns": ["id", "name"],"type": "unique"}}]');
         PersistObjectTemplate._verifySchema();
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).then(function () {
-            return knex('haven_schema1')
+            return knex(schemaTable)
                 .select('schema')
                 .orderBy('sequence_id', 'desc')
                 .limit(1)


### PR DESCRIPTION
Sam,
I found an issue with index synchronization logic. There is a problem with the logic when there are subtypes defined for a template. I've fixed that issue and also cleaned up some code. 

I also feel that we may need to run the index cleanup scripts once when we deploy these changes to uat and production as the index definitions might've been out of sync in these environments if we synchronize definitions from different branches. e.g. I don't see index on email field on customer table in my local database, but this is defined in schema.json object, but I don;t see this problem in our CI database. We can even delete all the records from haven_schema1 table.

Sorry I should've got this error earlier or at least realized when you were facing the issues, but for some reason, when I was running the unit tests, things were working fine.

Can you please accept this pull request.


Thanks,
Ravi