### PR TITLE
Fix to remove the fields of Array of objecttemplates from the change log.

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -403,7 +403,6 @@ module.exports = function (PersistObjectTemplate) {
                 for (var prop in props) {
                     var defineProperty = props[prop];
                     if (PersistObjectTemplate._persistProperty(defineProperty)) {
-                        checkFieldCaseChanges(table, info, prop);
                         if (!info[propToColumnName(prop)]) {
                             _newFields[prop] = props[prop];
                         }
@@ -497,14 +496,6 @@ module.exports = function (PersistObjectTemplate) {
                         .then(function() {}, function (e) {console.log(e)});
                 }
                 //console.log(table + "." + column + '=' + comment);
-            }
-            function checkFieldCaseChanges(table, info, prop) {
-                if (_.contains(_.keys(info), prop)) return;
-
-                var field = _.find(_.keys(info), function(key){ return key.toLowerCase() == prop.toLowerCase() })
-                if (field) {
-                    throw Error('Field ' + field + ' already exists on ' + table + ' table with a different case ');
-                }
             }
         }
     }

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -362,10 +362,14 @@ module.exports = function (PersistObjectTemplate) {
         function fieldChangeNotify(callBack, table) {
             if (!callBack) return;
             if (typeof callBack !== 'function')
-                throw new Error('persistor can only notify the field changes through a callback');
-            var fieldsChanged = _.keys(_newFields).join();
+                throw new Error('persistor can only notify the field changes through a callback')
+            var fieldsChanged = _.reduce(_newFields, function(current, field, key){
+                return field.type !== Array ? current + ',' + key: current;
+            }, '');
 
-            callBack('Following fields are being added to ' + table + ' table: \n    ' + fieldsChanged);
+            if (fieldsChanged.length > 0){
+                callBack('Following fields are being added to ' + table + ' table: \n ' + fieldsChanged.slice(1, fieldsChanged.length));
+            }
         }
         function columnMapper(table) {
 
@@ -399,6 +403,7 @@ module.exports = function (PersistObjectTemplate) {
                 for (var prop in props) {
                     var defineProperty = props[prop];
                     if (PersistObjectTemplate._persistProperty(defineProperty)) {
+                        checkFieldCaseChanges(table, info, prop);
                         if (!info[propToColumnName(prop)]) {
                             _newFields[prop] = props[prop];
                         }
@@ -492,6 +497,14 @@ module.exports = function (PersistObjectTemplate) {
                         .then(function() {}, function (e) {console.log(e)});
                 }
                 //console.log(table + "." + column + '=' + comment);
+            }
+            function checkFieldCaseChanges(table, info, prop) {
+                if (_.contains(_.keys(info), prop)) return;
+
+                var field = _.find(_.keys(info), function(key){ return key.toLowerCase() == prop.toLowerCase() })
+                if (field) {
+                    throw Error('Field ' + field + ' already exists on ' + table + ' table with a different case ');
+                }
             }
         }
     }

--- a/test/persist_banking.js
+++ b/test/persist_banking.js
@@ -241,18 +241,17 @@ function clearCollection(collectionName) {
 
 describe("Banking Example", function () {
 
-    it ("opens the database", function (done) {
+    it ("opens the database", function () {
         console.log("starting banking");
         return MongoClient.connect("mongodb://localhost:27017/testpersist").then(function (dbopen) {
             db = dbopen;
             PersistObjectTemplate.setDB(db);
             PersistObjectTemplate.setSchema(schema);
             PersistObjectTemplate.performInjections(); // Normally done by getTemplates
-            done();
-        }).catch(function(e){done(e)});;
+        }).catch(function(e){throw e;});
     });
 
-    it ("clears the bank", function (done) {
+    it ("clears the bank", function () {
         return clearCollection("role")
             .then(function (count) {
                 expect(count).to.equal(0);
@@ -262,8 +261,7 @@ describe("Banking Example", function () {
                 return clearCollection('customer')
             }).then(function (count) {
                 expect(count).to.equal(0);
-                done();
-            }).catch(function(e){done(e)});
+            }).catch(function(e){throw e;});
     });
 
     // Setup customers and addresses

--- a/test/persist_banking_pgsql.js
+++ b/test/persist_banking_pgsql.js
@@ -296,7 +296,7 @@ function clearCollection(template) {
 
 describe("Banking from pgsql Example", function () {
     var knex;
-    it ("opens the database Postgres", function (done) {
+    it ("opens the database Postgres", function () {
         console.log("starting banking");
         return Q()
             .then(function () {
@@ -311,22 +311,20 @@ describe("Banking from pgsql Example", function () {
                     }
                 });
                 PersistObjectTemplate.setDB(knex, PersistObjectTemplate.DB_Knex,  'pg');
-                done();
-        }).catch(function(e){done(e)});;
+            }).catch(function(e){throw e;});;
     });
 
-    it ("opens the database Mongo", function (done) {
+    it ("opens the database Mongo", function () {
         console.log("starting banking");
         return MongoClient.connect("mongodb://localhost:27017/testpersist").then(function (dbopen) {
             db = dbopen;
             PersistObjectTemplate.setDB(db, PersistObjectTemplate.DB_Mongo, 'mongo');
             PersistObjectTemplate.setSchema(schema);
             PersistObjectTemplate.performInjections(); // Normally done by getTemplates
-            done();
-        }).catch(function(e){done(e)});;
+        }).catch(function(e){throw e});
     });
 
-    it ("clears the bank", function (done) {
+    it ("clears the bank", function () {
         return clearCollection(Role)
             .then(function (count) {
                 expect(count).to.equal(0);
@@ -348,8 +346,7 @@ describe("Banking from pgsql Example", function () {
                 return clearCollection(Address)
             }).then(function (count) {
                 expect(count).to.equal(0);
-                done();
-            }).catch(function(e){done(e)});
+            }).catch(function(e){throw e});
     });
     var sam;
     var karen;
@@ -393,7 +390,7 @@ describe("Banking from pgsql Example", function () {
         jointAccount.addCustomer(ashling, "joint");
 
         samsAccount.credit(100);                        // Sam has 100
-        samsAccount.debit(50)                           // Sam has 50
+        samsAccount.debit(50);                          // Sam has 50
         jointAccount.credit(200);                       // Joint has 200
         jointAccount.transferTo(100, samsAccount);      // Joint has 100, Sam has 150
         jointAccount.transferFrom(50, samsAccount);     // Joint has 150, Sam has 100
@@ -780,7 +777,7 @@ describe("Banking from pgsql Example", function () {
         });
     });
 
-    it("Can get update conflicts", function (done) {
+    it("Can get update conflicts", function () {
         var customer;
         var isStale = false;
         return Customer.getFromPersistWithId(sam._id).then (function (sam) {
@@ -800,11 +797,10 @@ describe("Banking from pgsql Example", function () {
         }).catch(function(e) {
             expect(e.message).to.equal("Update Conflict");
             expect(isStale).to.equal(true);
-            done()
         });
     });
 
-    it("Can transact", function (done) {
+    it("Can transact", function () {
         var customer;
         var preSave = false;
         this.dirtyCount = 0;
@@ -829,15 +825,14 @@ describe("Banking from pgsql Example", function () {
             expect(customer.primaryAddresses[0].city).to.equal("The Big Apple");
             expect(preSave).to.equal(true);
             expect(this.dirtyCount).to.equal(2);
-            done();
         }).catch(function(e) {
-            done(e)
+            throw e;
         });
     });
     it("Can get update conflicts on txn end and rollback", function (done) {
         var customer;
         var txn;
-        return Customer.getFromPersistWithId(sam._id).then (function (c) {
+        Customer.getFromPersistWithId(sam._id).then (function (c) {
             customer = c;
             expect(customer.secondaryAddresses[0].city).to.equal("Rhinebeck");
             expect(customer.primaryAddresses[0].city).to.equal("The Big Apple");
@@ -861,7 +856,7 @@ describe("Banking from pgsql Example", function () {
         });
     });
 
-    it("Can get update conflicts on txn end and rollback", function (done) { // Try again with a conflict on 2nd
+    it("Can get update conflicts on txn end and rollback", function () { // Try again with a conflict on 2nd
         var customer;
         var txn;
         return Customer.getFromPersistWithId(sam._id).then (function (c) {
@@ -882,9 +877,8 @@ describe("Banking from pgsql Example", function () {
         }).then(function(customer) {
             expect(customer.secondaryAddresses[0].city).to.equal("Rhinebeck");
             expect(customer.primaryAddresses[0].city).to.equal("The Big Apple");
-            done();
         }).catch(function(e) {
-            done(e)
+            throw e;
         });
     });
 

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -369,25 +369,4 @@ describe('index synchronization checks', function () {
    
         });
     });
-
-    it('Using the same field with different case should throw an exception', function () {
-        schema.caseChangeCheck = {};
-        schema.caseChangeCheck.documentOf = "pg/caseChangeCheck";
-        var caseChangeCheck = PersistObjectTemplate.create("caseChangeCheck", {
-            id: {type: String},
-            name: {type: String, value: "PrimaryIndex"},
-            fieldToChange: {type: String},
-            init: function (id, name) {
-                this.id = id;
-                this.name = name;
-            }
-        });
-        PersistObjectTemplate._verifySchema();
-        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(caseChangeCheck).then(function (result) {
-            caseChangeCheck.mixin({FIELDTOCHANGE: {type: String}});
-
-            PersistObjectTemplate._verifySchema();
-            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(caseChangeCheck).should.be.rejectedWith(Error, 'with a different case')
-        });
-    });
 });

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -244,6 +244,7 @@ describe('index synchronization checks', function () {
 
         return Q.all([
             knex.schema.dropTableIfExists('notificationCheck'),
+            knex.schema.dropTableIfExists('caseChangeCheck'),
             PersistObjectTemplate.dropKnexTable(Employee),
             //PersistObjectTemplate.dropKnexTable(Manager),
             PersistObjectTemplate.dropKnexTable(BoolTable),
@@ -253,9 +254,7 @@ describe('index synchronization checks', function () {
             PersistObjectTemplate.dropKnexTable(MultipleIndexTable),
             PersistObjectTemplate.dropKnexTable(Parent),
             knex(schemaTable).del(),
-            knex.schema.hasTable('IndexSyncTable').then(function(exists){
-                if (exists) knex.schema.dropTable('IndexSyncTable');
-            })
+            knex.schema.dropTableIfExists('IndexSyncTable')
         ]).should.notify(done);
     });
 
@@ -273,7 +272,7 @@ describe('index synchronization checks', function () {
    
     it('calling synchronizeKnexTableFromTemplate without any changes to the schema definitions..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(IndexSyncTable).should.eventually.be.fulfilled;
-    })
+    });
    
     it('synchronize the index definition for a new table and leave it in the schema table..', function () {
         return  PersistObjectTemplate.synchronizeKnexTableFromTemplate(MultipleIndexTable).then(function(){
@@ -331,11 +330,10 @@ describe('index synchronization checks', function () {
     });
    
     it('adding a new field and verifying the notification', function () {
-        function fieldsNotify(fields){
-            console.log(fields);
-        };
-   
-   
+        function fieldsNotify(fields) {
+            expect(fields).to.match(/newField|notificationCheck/);
+        }
+        
         schema.notificationCheck = {};
         schema.notificationCheck.documentOf = "pg/notificationCheck";
         var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
@@ -345,7 +343,7 @@ describe('index synchronization checks', function () {
                 this.id = id;
                 this.name = name;
             }
-        })
+        });
         PersistObjectTemplate._verifySchema();
         return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function (result) {
             var notificationCheck = PersistObjectTemplate.create("notificationCheck", {
@@ -359,21 +357,37 @@ describe('index synchronization checks', function () {
             });
    
             PersistObjectTemplate._verifySchema();
-            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify).then(function () {
-   
-            });
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(notificationCheck, fieldsNotify);
         });
     });
    
     it("creating parent and child and synchronize the parent to check the child table indexes", function (done) {
-        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (result) {
-            return Q.all([getIndexes('Employee').should.eventually.have.length(2),
+         PersistObjectTemplate.synchronizeKnexTableFromTemplate(Employee).then(function (result) {
+             Q.all([getIndexes('Employee').should.eventually.have.length(2),
                 getIndexes('Manager').should.eventually.have.length(1),
                 getIndexes('Executive').should.eventually.have.length(1)]).should.notify(done);
    
         });
     });
 
-   
+    it('Using the same field with different case should throw an exception', function () {
+        schema.caseChangeCheck = {};
+        schema.caseChangeCheck.documentOf = "pg/caseChangeCheck";
+        var caseChangeCheck = PersistObjectTemplate.create("caseChangeCheck", {
+            id: {type: String},
+            name: {type: String, value: "PrimaryIndex"},
+            fieldToChange: {type: String},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        });
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(caseChangeCheck).then(function (result) {
+            caseChangeCheck.mixin({FIELDTOCHANGE: {type: String}});
 
-})
+            PersistObjectTemplate._verifySchema();
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(caseChangeCheck).should.be.rejectedWith(Error, 'with a different case')
+        });
+    });
+});


### PR DESCRIPTION
Sam,
I removed the field case checks from persistor and left only the fix related to new fields and tables email subscription. 

I need to fix mocha tests as the latest mocha framework would not allow us to return promise as well as calling done function. We've to do one of these two things to conclude the tests.

Thanks,
Ravi