### PR TITLE
New table creation should add comments

### DIFF
--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -491,23 +491,6 @@ module.exports = function (PersistObjectTemplate) {
                         }
                     }
                 }
-                // for (var columnName in info) {
-                //     var prop = columnNameToProp(columnName);
-                //     if (!prop) {
-                //         PersistObjectTemplate.logger.info({component: 'persistor', module: 'db.synchronizeKnexTableFromTemplate', activity: 'discoverColumns'}, "Extra column " + columnName + " on " + table);
-                //         commentOn(table, columnName, 'now obsolete');
-                //     } else {
-                //         if (prop == '_id')
-                //             commentOn(table, columnName, "primary key");
-                //         else if (prop.match(/:/)) {
-                //             prop = prop.substr(1);
-                //             commentOn(table, columnName, getForeignKeyDescription(props[prop]));
-                //         } else if (prop == '_template')
-                //             commentOn(table, columnName, getClassNames(prop));
-                //         else if (prop != '__version__')
-                //             commentOn(table, columnName, getDescription(prop, props[prop]));
-                //     }
-                // }
             });
 
             function propToColumnName(prop) {

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -357,6 +357,7 @@ module.exports = function (PersistObjectTemplate) {
                     }
                 }.bind(this))
             }.bind(this))
+            .then(addComments.bind(this, tableName))
             .then(synchronizeIndexes.bind(this, tableName, template));
 
         function fieldChangeNotify(callBack, table) {
@@ -396,23 +397,8 @@ module.exports = function (PersistObjectTemplate) {
                     table.text(prop);
             }
         }
-
-
-        function discoverColumns(table) {
+        function addComments(table){
             return knex(table).columnInfo().then(function (info) {
-                for (var prop in props) {
-                    var defineProperty = props[prop];
-                    if (PersistObjectTemplate._persistProperty(defineProperty)) {
-                        if (!info[propToColumnName(prop)]) {
-                            _newFields[prop] = props[prop];
-                        }
-                        else {
-                            if (!iscompatible(props[prop].type.name, info[propToColumnName(prop)].type)) {
-                                throw new Error("changing types for the fields is not allowed, please use scripts to make these changes");
-                            }
-                        }
-                    }
-                }
                 for (var columnName in info) {
                     var prop = columnNameToProp(columnName);
                     if (!prop) {
@@ -432,15 +418,6 @@ module.exports = function (PersistObjectTemplate) {
                 }
             });
 
-            function propToColumnName(prop) {
-                var defineProperty = props[prop];
-                if (defineProperty.type.__objectTemplate__)
-                    if (!schema || !schema.parents || !schema.parents[prop] || !schema.parents[prop].id)
-                        throw   new Error(template.__name__ + "." + prop + " is missing a parents schema entry");
-                    else
-                        prop = (schema.parents && schema.parents[prop]) ? schema.parents[prop].id : prop;
-                return prop;
-            }
             function columnNameToProp(columnName) {
                 if (columnName  == '_id' || columnName == '__version__' || columnName == '_template')
                     return columnName;
@@ -497,6 +474,52 @@ module.exports = function (PersistObjectTemplate) {
                 }
                 //console.log(table + "." + column + '=' + comment);
             }
+        }
+
+        function discoverColumns(table) {
+            return knex(table).columnInfo().then(function (info) {
+                for (var prop in props) {
+                    var defineProperty = props[prop];
+                    if (PersistObjectTemplate._persistProperty(defineProperty)) {
+                        if (!info[propToColumnName(prop)]) {
+                            _newFields[prop] = props[prop];
+                        }
+                        else {
+                            if (!iscompatible(props[prop].type.name, info[propToColumnName(prop)].type)) {
+                                throw new Error("changing types for the fields is not allowed, please use scripts to make these changes");
+                            }
+                        }
+                    }
+                }
+                // for (var columnName in info) {
+                //     var prop = columnNameToProp(columnName);
+                //     if (!prop) {
+                //         PersistObjectTemplate.logger.info({component: 'persistor', module: 'db.synchronizeKnexTableFromTemplate', activity: 'discoverColumns'}, "Extra column " + columnName + " on " + table);
+                //         commentOn(table, columnName, 'now obsolete');
+                //     } else {
+                //         if (prop == '_id')
+                //             commentOn(table, columnName, "primary key");
+                //         else if (prop.match(/:/)) {
+                //             prop = prop.substr(1);
+                //             commentOn(table, columnName, getForeignKeyDescription(props[prop]));
+                //         } else if (prop == '_template')
+                //             commentOn(table, columnName, getClassNames(prop));
+                //         else if (prop != '__version__')
+                //             commentOn(table, columnName, getDescription(prop, props[prop]));
+                //     }
+                // }
+            });
+
+            function propToColumnName(prop) {
+                var defineProperty = props[prop];
+                if (defineProperty.type.__objectTemplate__)
+                    if (!schema || !schema.parents || !schema.parents[prop] || !schema.parents[prop].id)
+                        throw   new Error(template.__name__ + "." + prop + " is missing a parents schema entry");
+                    else
+                        prop = (schema.parents && schema.parents[prop]) ? schema.parents[prop].id : prop;
+                return prop;
+            }
+
         }
     }
 

--- a/test/persist_polymorphic.js
+++ b/test/persist_polymorphic.js
@@ -559,6 +559,9 @@ describe('type mapping tests for parent/child relations', function () {
             PersistObjectTemplate.dropKnexTable(Scenario_2_ParentWithMultiChildAttheSameLevel),
             PersistObjectTemplate.dropKnexTable(ParentWithMultiChildAttheSameLevelWithIndexes),
             PersistObjectTemplate.dropKnexTable(parentSynchronize),
+            knex.schema.dropTableIfExists('NewTableWithComments'),
+            knex.schema.dropTableIfExists('ExistingTableWithComments'),
+            knex.schema.dropTableIfExists('ExistingTableWithAField'),
             knex('index_schema_history').del()
         ]).should.notify(done);;
     })
@@ -642,10 +645,87 @@ describe('type mapping tests for parent/child relations', function () {
             return PersistObjectTemplate.checkForKnexTable(parentSynchronize).should.eventually.equal(true).then(function(){
                 schema.childSynchronize.indexes = JSON.parse('[{"name": "scd_index","def": {"columns": ["name"],"type": "unique"}}]');
                    return PersistObjectTemplate.synchronizeKnexTableFromTemplate(childSynchronize);
-                   // return Q();
             })
         })
     
+    });
+
+
+    it("Create a new table and check if the comments added to the fields are included in the database", function () {
+        var NewTableWithComments = PersistObjectTemplate.create("NewTableWithComments", {
+            id: {type: Number},
+            name: {type: String, value: 'Test Parent', comment: 'comment on a new table...'},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        })
+
+        schema.NewTableWithComments = {documentOf: "pg/NewTableWithComments"};
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(NewTableWithComments).then(function (status) {
+           return knex('pg_catalog.pg_description')
+               .count()
+               .where('description', 'like', '%comment on a new table...%')
+               .should.eventually.contain({ count: '1' });
+
+        })
+
+    });
+
+    it("Adding a comment to an existing table", function () {
+        var ExistingTableWithComments = PersistObjectTemplate.create("ExistingTableWithComments", {
+            id: {type: Number},
+            name: {type: String, value: 'Test Parent'},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        })
+
+        schema.ExistingTableWithComments = {documentOf: "pg/ExistingTableWithComments"};
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(ExistingTableWithComments).then(function (status) {
+            ExistingTableWithComments.mixin({
+                name: {type: String, value: 'Test Parent', comment:    'comment on an existing table'}
+            });
+            PersistObjectTemplate._verifySchema();
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(ExistingTableWithComments).then(function (status) {
+                return knex('pg_catalog.pg_description')
+                    .count()
+                    .where('description', 'like', '%comment on an existing table%')
+                    .should.eventually.contain({ count: '1' });
+
+            })
+        })
+
+    });
+
+    it("Adding a new field with comment to an existing table", function () {
+        var ExistingTableWithAField = PersistObjectTemplate.create("ExistingTableWithAField", {
+            id: {type: Number},
+            name: {type: String, value: 'Test Parent'},
+            init: function (id, name) {
+                this.id = id;
+                this.name = name;
+            }
+        });
+
+        schema.ExistingTableWithAField = {documentOf: "pg/ExistingTableWithAField"};
+        PersistObjectTemplate._verifySchema();
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(ExistingTableWithAField).then(function (status) {
+            ExistingTableWithAField.mixin({
+                newField: {type: String, value: 'Test Parent', comment:    'Adding a new field comment'}
+            });
+            PersistObjectTemplate._verifySchema();
+            return PersistObjectTemplate.synchronizeKnexTableFromTemplate(ExistingTableWithAField).then(function (status) {
+                return knex('pg_catalog.pg_description')
+                    .count()
+                    .where('description', 'like', '%Adding a new field comment%')
+                    .should.eventually.contain({ count: '1' });
+            })
+        });
+
     });
 })
 


### PR DESCRIPTION
Sam,
As discussed earlier, we've a problem with adding comments for new tables. I've fixed the issue
by adding a few function called addComments and including it as a last step in synchronizeKnexTableFromTemplate. I moved all the functions related to comments from discoverColumns function to the new function. I've also included 3 test cases to cover the comments verification.

Can you please accept this pull request as soon as possible.

Thanks,
Ravi