### PR TITLE
Persistor changes

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -187,11 +187,11 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
         /**
          * Fetch an object by id
-         * @param id
-         * @param options
+         * @param {string} id mongo style id
+         * @param {json} options @todo
          * @returns {*}
          */
-        template.persistorFetchById = function(id, options) { // Todo: Legacy
+        template.persistorFetchById = function(id, options) { // @TODO: Legacy
             PersistObjectTemplate._validateParams(options, 'fetchSchema', template);
 
             options = options || {};
@@ -207,8 +207,8 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
         /**
          * Delete all objects matching a query
-         * @param query
-         * @param options
+         * @param {JSON} query @TODO
+         * @param {JSON} options @TODO
          * @returns {Object}
          */
         template.persistorDeleteByQuery = function(query, options) {
@@ -223,8 +223,8 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
         /**
          * Fetch all objects matching a query
-         * @param query
-         * @param options
+         * @param {JSON} query @TODO
+         * @param {JSON} options @TODO
          * @returns {*}
          */
         template.persistorFetchByQuery = function(query, options) {
@@ -246,7 +246,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * Return count of objects of this class given a json query
          *
          * @param {json} query mongo style queries
-         * @param {object} logger objecttemplate logger
+         * @param {object} options @TODO
          * @returns {Number}
          */
         template.persistorCountByQuery = function(query, options) {
@@ -837,8 +837,9 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
     /**
      * Mostly used for unit testing.  Does a knex connect, schema setup and injects templates
-     * @param config
-     * @param schema
+     * @param {object} config knex connection
+     * @param {JSON} schema data model definitions
+     * @returns {*}
      */
     PersistObjectTemplate.connect = function (config, schema) {
         var knex = require('knex');
@@ -870,6 +871,8 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
     }
     /**
      * Mostly used for unit testing.  Synchronize all tables for templates that have a schema
+     * @param {string} action common actions
+     * @param {string} concurrency #parallel
      * @returns {*|Array}
      */
     PersistObjectTemplate.onAllTables = function (action, concurrency) {

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -518,7 +518,7 @@ module.exports = function (PersistObjectTemplate) {
                 }
             }
         }
-  
+
         function discoverColumns(table) {
             return knex(table).columnInfo().then(function (info) {
                 for (var prop in props) {
@@ -763,18 +763,18 @@ module.exports = function (PersistObjectTemplate) {
 
     function iscompatible(persistortype, pgtype) {
         switch (persistortype) {
-            case 'String':
-            case 'Object':
-            case 'Array':
-                return pgtype.indexOf('text') > -1;
-            case 'Number':
-                return pgtype.indexOf('double precision') > -1;
-            case 'Boolean':
-                return pgtype.indexOf('bool') > -1;
-            case 'Date':
-                return pgtype.indexOf('timestamp') > -1;
-            default:
-                return pgtype.indexOf('text') > -1; // Typed objects have no name
+        case 'String':
+        case 'Object':
+        case 'Array':
+            return pgtype.indexOf('text') > -1;
+        case 'Number':
+            return pgtype.indexOf('double precision') > -1;
+        case 'Boolean':
+            return pgtype.indexOf('bool') > -1;
+        case 'Date':
+            return pgtype.indexOf('timestamp') > -1;
+        default:
+            return pgtype.indexOf('text') > -1; // Typed objects have no name
         }
     }
 

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -330,8 +330,9 @@ module.exports = function (PersistObjectTemplate) {
                 if (txn && txn.onUpdateConflict) {
                     txn.onUpdateConflict(obj);
                     txn.updateConflict =  true;
-                } else
+                } else {
                     throw new Error('Update Conflict');
+                }
             }
         }
 
@@ -1154,10 +1155,10 @@ module.exports = function (PersistObjectTemplate) {
             }
 
             function rollback (err) {
-                return knexTransaction.rollback().then (function () {
-                    var deadlock = err.toString().match(/deadlock detected$/i)
-                    persistorTransaction.innerError = err;
-                    innerError = deadlock ? new Error('Update Conflict') : err;
+                var deadlock = err.toString().match(/deadlock detected$/i);
+                persistorTransaction.innerError = err;
+                innerError = deadlock ? new Error('Update Conflict') : err;
+                return knexTransaction.rollback(innerError).then (function () {
                     (logger || this.logger).debug({component: 'persistor', module: 'api', activity: 'end'}, 'transaction rolled back ' +
                         innerError.message + (deadlock ? ' from deadlock' : ''));
                 }.bind(this));

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -366,7 +366,12 @@ module.exports = function (PersistObjectTemplate) {
         var schema = template.__schema__;
         var _newFields = {};
 
-        return Promise.resolve().then(function () {
+        return Promise.resolve()
+            .then(buildTable.bind(this))
+            .then(addComments.bind(this, tableName))
+            .then(synchronizeIndexes.bind(this, tableName, template));
+
+        function buildTable() {
             return knex.schema.hasTable(tableName).then(function (exists) {
                 if (!exists) {
                     if (!!changeNotificationCallback) {
@@ -383,10 +388,7 @@ module.exports = function (PersistObjectTemplate) {
                     }.bind(this));
                 }
             }.bind(this))
-        }.bind(this))
-
-            .then(addComments.bind(this, tableName))
-            .then(synchronizeIndexes.bind(this, tableName, template));
+        }
 
         function fieldChangeNotify(callBack, table) {
             if (!callBack) return;
@@ -506,8 +508,8 @@ module.exports = function (PersistObjectTemplate) {
                 }
             }
             function commentOn(table, column, comment) {
-                if (knex.client.config.client == 'pg') {
-                    knex.raw('COMMENT ON COLUMN "' + table + '"."' + column + '" IS \'' + comment.replace(/'/g, '\'\'') + '\';')
+                if (knex.client.config.client === 'pg' && comment !== '') {
+                    return knex.raw('COMMENT ON COLUMN "' + table + '"."' + column + '" IS \'' + comment.replace(/'/g, '\'\'') + '\';')
                         .then(function() {}, function (e) {
                             /*eslint-disable no-console*/
                             console.log(e)
@@ -516,7 +518,7 @@ module.exports = function (PersistObjectTemplate) {
                 }
             }
         }
-
+  
         function discoverColumns(table) {
             return knex(table).columnInfo().then(function (info) {
                 for (var prop in props) {
@@ -761,18 +763,18 @@ module.exports = function (PersistObjectTemplate) {
 
     function iscompatible(persistortype, pgtype) {
         switch (persistortype) {
-        case 'String':
-        case 'Object':
-        case 'Array':
-            return pgtype.indexOf('text') > -1;
-        case 'Number':
-            return pgtype.indexOf('double precision') > -1;
-        case 'Boolean':
-            return pgtype.indexOf('bool') > -1;
-        case 'Date':
-            return pgtype.indexOf('timestamp') > -1;
-        default:
-            return pgtype.indexOf('text') > -1; // Typed objects have no name
+            case 'String':
+            case 'Object':
+            case 'Array':
+                return pgtype.indexOf('text') > -1;
+            case 'Number':
+                return pgtype.indexOf('double precision') > -1;
+            case 'Boolean':
+                return pgtype.indexOf('bool') > -1;
+            case 'Date':
+                return pgtype.indexOf('timestamp') > -1;
+            default:
+                return pgtype.indexOf('text') > -1; // Typed objects have no name
         }
     }
 

--- a/lib/knex/query.js
+++ b/lib/knex/query.js
@@ -207,7 +207,7 @@ module.exports = function (PersistObjectTemplate) {
                 obj._id = pojo[prefix + '_id'];
                 obj._template = pojo[prefix + '_template'];
             }.bind(this));
-            if (!establishedObj && idMap[obj._id])
+            if (!establishedObj && idMap[obj._id] && allRequiredChildrenAvailableInCache(idMap[obj._id], cascade))
                 return Promise.resolve(idMap[obj._id]);
 
             idMap[obj._id] = obj;
@@ -269,7 +269,7 @@ module.exports = function (PersistObjectTemplate) {
 
                     // Return copy if already there
                     var cachedObject = idMap[foreignId];
-                    if (cachedObject) {
+                    if (cachedObject && (!cascadeFetch || allRequiredChildrenAvailableInCache(cachedObject, cascadeFetch.fetch))) {
                         if (!obj[prop] || obj[prop].__id__ != cachedObject.__id__) {
                             this.withoutChangeTracking(function () {
                                 obj[prop] = cachedObject;
@@ -460,6 +460,12 @@ module.exports = function (PersistObjectTemplate) {
                         }.bind(this))
                 }.bind(this));
 
+            }
+
+            function allRequiredChildrenAvailableInCache(cachedObject, fetchSpec) {
+                return Object.keys(fetchSpec).reduce(function(loaded, currentObj) {
+                    return loaded && (!fetchSpec[currentObj] || cachedObject[currentObj + 'Persistor'].isFetched)
+                }, true);
             }
         };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/selsamman/persistor",
-    "version": "2.3.0",
+    "version": "2.2.1",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
     "name": "persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/selsamman/persistor",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.0",
         "underscore": "1.x",
         "mongodb-bluebird": "x",
         "bluebird": "x",
-        "knex": "0.11.1",
+        "knex": "*",
         "pg":"*",
         "tv4": "^1.2.7"
     },

--- a/test/persist_banking_pgsql.js
+++ b/test/persist_banking_pgsql.js
@@ -328,7 +328,7 @@ describe('Banking from pgsql Example', function () {
     var schemaTable = 'index_schema_history';
     it ('clears the bank', function () {
         return knex.schema.dropTableIfExists(schemaTable)
-            .then(function (count) {
+            .then(function () {
                 return clearCollection(Role);
             }).then(function (count) {
                 expect(count).to.equal(0);

--- a/test/persist_fetch_children.js
+++ b/test/persist_fetch_children.js
@@ -1,0 +1,157 @@
+var chai = require('chai'),
+    expect = require('chai').expect;
+
+var chaiAsPromised = require('chai-as-promised');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+var Promise = require('bluebird');
+
+var knex = require('knex')({
+    client: 'pg',
+    debug: true,
+    connection: {
+        host: '127.0.0.1',
+        database: 'persistor_banking',
+        user: 'postgres',
+        password: 'postgres'
+    }
+});
+
+
+
+var schema = {};
+var schemaTable = 'index_schema_history';
+var Employee, Department, Role, roleId;
+var PersistObjectTemplate, ObjectTemplate;
+describe('persistor transaction checks', function () {
+    before('drop schema table once per test suit', function() {
+        return Promise.all([
+
+            knex.schema.dropTableIfExists('tx_employee')
+            .then(function () {
+                return knex.schema.dropTableIfExists('tx_role')
+            }).then(function () {
+                return knex.schema.dropTableIfExists('tx_department')
+            }),
+            knex.schema.dropTableIfExists(schemaTable)]);
+    })
+    beforeEach('arrange', function () {
+        ObjectTemplate = require('supertype');
+        PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);
+
+        schema.Employee = {};
+        schema.Department = {};
+        schema.Role = {};
+        schema.Role.table = 'tx_role';
+        schema.Employee.table = 'tx_employee';
+        schema.Department.table = 'tx_department';
+
+
+        schema.Employee.parents = {
+            department: {id: 'department_id'}
+        };
+        schema.Employee.children = {
+            roles: {id: 'employee_id'}
+        };
+        schema.Role.parents = {
+            employee: {id: 'employee_id'},
+            department: {id: 'role_id'}
+        };
+
+
+        schema.Department.children = {
+            employees: {id: 'employee_id'}
+        };
+        schema.Department.parents = {
+            manager: {id: 'manager_id'}
+        };
+
+        Employee = PersistObjectTemplate.create('Employee', {
+            name: {type: String}
+        });
+
+        Department = PersistObjectTemplate.create('Department', {
+            name: {type: String},
+            manager: {type: Employee}
+        });
+
+        Role = PersistObjectTemplate.create('Role', {
+            name: {type:String}
+        });
+
+        Employee.mixin({
+            department: {type: Department},
+            roles: {type: Array, of: Role, value: []}
+        })
+
+
+        Role.mixin({
+            employee: {type: Employee},
+            department: {type: Department}
+        });
+        var emp = new Employee();
+        var role1 = new Role();
+        var dep1  = new Department();
+        role1.name = 'firstRole';
+        role1.employee = emp;
+        role1.department = dep1;
+        dep1.manager = emp;
+        var role2 = new Role();
+        role2.name = 'secondRole';
+        role2.employee = emp;
+        role2.department = dep1;
+
+        emp.department = dep1;
+        emp.roles = [role1, role2];
+
+
+        (function () {
+            PersistObjectTemplate.setDB(knex, PersistObjectTemplate.DB_Knex);
+            PersistObjectTemplate.setSchema(schema);
+            PersistObjectTemplate.performInjections();
+
+        })();
+        return Promise.resolve(prepareData());
+
+        function prepareData() {
+            PersistObjectTemplate.performInjections();
+            return syncTable(Employee)
+                .then(syncTable.bind(this, Department))
+                .then(syncTable.bind(this, Role))
+                .then(createRecords.bind(Employee));
+
+
+            function syncTable(template) {
+                return PersistObjectTemplate.synchronizeKnexTableFromTemplate(template);
+            }
+
+            function createRecords() {
+                var tx =  PersistObjectTemplate.begin();
+                emp.setDirty(tx);
+                return PersistObjectTemplate.end(tx).then(function() {
+                    roleId = emp.roles[0]._id;
+                });
+            }
+        }
+    });
+
+    afterEach('remove tables and after each test', function() {
+        return Promise.all([
+            knex.schema.dropTableIfExists('tx_employee')
+           .then(function () {
+                return knex.schema.dropTableIfExists('tx_department')
+            }).then(function () {
+                return knex.schema.dropTableIfExists('tx_role')
+            }),
+            knex.schema.dropTableIfExists(schemaTable)]);
+    });
+
+    it('load intermediate objects first and then try to load the parents ', function () {
+        return Role.getFromPersistWithId(roleId, {employee: {fetch: {department: {fetch: {manager: {fetch: {roles: true}}}}}}}).then(function(role) {
+            expect(role.employee.department.manager.roles.length).is.equal(2);
+        });
+    });
+
+});

--- a/test/persist_fetch_children.js
+++ b/test/persist_fetch_children.js
@@ -141,10 +141,10 @@ describe('persistor transaction checks', function () {
         return Promise.all([
             knex.schema.dropTableIfExists('tx_employee')
            .then(function () {
-                return knex.schema.dropTableIfExists('tx_department')
-            }).then(function () {
-                return knex.schema.dropTableIfExists('tx_role')
-            }),
+               return knex.schema.dropTableIfExists('tx_department')
+           }).then(function () {
+               return knex.schema.dropTableIfExists('tx_role')
+           }),
             knex.schema.dropTableIfExists(schemaTable)]);
     });
 

--- a/test/persist_newapi_extend.js
+++ b/test/persist_newapi_extend.js
@@ -1,0 +1,97 @@
+var chai = require('chai'),
+    expect = require('chai').expect;
+
+var chaiAsPromised = require('chai-as-promised');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+var Promise = require('bluebird');
+
+var knex = require('knex')({
+    client: 'pg',
+    connection: {
+        host: '127.0.0.1',
+        database: 'persistor_banking',
+        user: 'postgres',
+        password: 'postgres'
+    }
+});
+
+var schema = {};
+var schemaTable = 'index_schema_history';
+var Employee, Person, empId;
+var PersistObjectTemplate, ObjectTemplate;
+
+describe('persistor transaction checks', function () {
+    before('drop schema table once per test suit', function() {
+        return Promise.all([knex.schema.dropTableIfExists('tx_person'),
+            knex.schema.dropTableIfExists(schemaTable)]);
+    })
+    beforeEach('arrange', function () {
+        ObjectTemplate = require('supertype');
+        PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);
+        schema.Person = {};
+        schema.Person.table =  'tx_person';
+        //schema.Employee.documentOf = 'tx_person';
+        Person = PersistObjectTemplate.create('Person', {
+            firstName: {type: String},
+            lastName: {type: String}
+        });
+        Employee = Person.extend('Employee', {
+            salary: {type: Number}
+        });
+
+        var emp = new Employee();
+        emp.firstName = 'test firstName';
+        emp.lastName = 'lastName';
+        emp.salary = 10000;
+        (function () {
+            PersistObjectTemplate.setDB(knex, PersistObjectTemplate.DB_Knex);
+            PersistObjectTemplate.setSchema(schema);
+            PersistObjectTemplate.performInjections();
+
+        })();
+        return Promise.resolve(prepareData());
+
+        function prepareData() {
+            PersistObjectTemplate.performInjections();
+            return syncTable(Employee)
+                .then(createRecords.bind(this));
+
+
+            function syncTable(template) {
+                return PersistObjectTemplate.synchronizeKnexTableFromTemplate(template);
+            }
+
+            function createRecords() {
+                var tx =  PersistObjectTemplate.beginDefaultTransaction();
+                return emp.persist({transaction: tx, cascade: false}).then(function() {
+                    return PersistObjectTemplate.commit({transaction: tx}).then(function() {
+                        empId = emp._id;
+                    });
+                })
+            }
+        }
+    });
+
+    afterEach('remove tables and after each test', function() {
+        return Promise.all([
+            knex.schema.dropTableIfExists('tx_person'),
+            knex.schema.dropTableIfExists(schemaTable)]);
+    });
+
+    it('persistorFetchById without fetch spec should not return the records', function () {
+        return Employee.persistorFetchById(empId)
+            .then(function(employee) {
+                expect(employee.firstName).is.not.equal(null);
+            });
+    });
+    it('fetch without fetch spec should not return the records', function () {
+        return Employee.persistorFetchByQuery({salary: 10000}).then(function(employee) {
+            expect(employee[0].firstName).is.equal(null);
+        }).catch(function(err) {
+            expect(err).not.equal(null);
+        });
+    });
+});

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -105,13 +105,13 @@ var schema = {
                 type: 'unique'
             }
         },
-        {
-            name: 'new_index',
-            def: {
-                columns: ['id'],
-                type: 'unique'
-            }
-        }]
+            {
+                name: 'new_index',
+                def: {
+                    columns: ['id'],
+                    type: 'unique'
+                }
+            }]
     },
     Manager: {
         documentOf: 'pg/Manager',

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -408,7 +408,7 @@ describe('schema update checks', function () {
 
         var newTableWithoutTableDef = PersistObjectTemplate.create('newTableWithoutTableDef', {
             id: {type: String},
-            name: {type: String, value: 'PrimaryIndex'},
+            name: {type: String, value: 'PrimaryIndex', description:'comment name'},
             init: function (id, name) {
                 this.id = id;
                 this.name = name;
@@ -423,7 +423,7 @@ describe('schema update checks', function () {
                     addresses: {type: Array, of: AddressForMissingTableDef, value: []},
                     isMarried: {type: Boolean},
                     numberOfKids: {type: Number},
-                    dob: {type:Date }
+                    dob: {type:Date, description:'comment date' }
                 });
             PersistObjectTemplate._verifySchema();
             return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTableWithoutTableDef)


### PR DESCRIPTION
Following 3 issues are being fixed:
1. fixed the issue related to knex rollback - this will allow us to get the latest knex version.
2. add comments on db fields has an issue with promise chain which can cause deadlocks, also included a condition to run the query only when there is a comment to add.
3. Some child records may be missing in objects even when the fetch spec includes these children, this is because of returning the object from the cache when it's being loaded through a different fetch spec path.
4. Added unit tests to cover the fix in #3.

Thanks,
Ravi
