### PR TITLE
Persistor Changes

### DIFF
--- a/lib/knex/query.js
+++ b/lib/knex/query.js
@@ -269,7 +269,7 @@ module.exports = function (PersistObjectTemplate) {
 
                     // Return copy if already there
                     var cachedObject = idMap[foreignId];
-                    if (cachedObject && (!cascadeFetch || allRequiredChildrenAvailableInCache(cachedObject, cascadeFetch.fetch))) {
+                    if (cachedObject && (!cascadeFetch  || !cascadeFetch.fetch || allRequiredChildrenAvailableInCache(cachedObject, cascadeFetch.fetch))) {
                         if (!obj[prop] || obj[prop].__id__ != cachedObject.__id__) {
                             this.withoutChangeTracking(function () {
                                 obj[prop] = cachedObject;

--- a/lib/util.js
+++ b/lib/util.js
@@ -262,7 +262,7 @@ module.exports = function (PersistObjectTemplate) {
                 });
             }
 
-            function getKeyTemplate(key, template) {
+            function getKeyTemplate(template) {
                 if (template.type && template.type.isObjectTemplate) {
                     return template.type;
                 }
@@ -273,11 +273,11 @@ module.exports = function (PersistObjectTemplate) {
 
             function isFetchKeyInDefineProperties(key, template) {
                 if (key in template.defineProperties) {
-                    return getKeyTemplate(key, template.defineProperties[key]);
+                    return getKeyTemplate(template.defineProperties[key]);
                 }
                 else {
-                    return template.__children__.reduce(function(found, child) {
-                        return found || isFetchKeyInDefineProperties(key, child)
+                    return template.__children__.reduce(function(keyTemplate, child) {
+                        return keyTemplate || isFetchKeyInDefineProperties(key, child)
                     }, null);
                 }
             }

--- a/lib/util.js
+++ b/lib/util.js
@@ -232,7 +232,7 @@ module.exports = function (PersistObjectTemplate) {
         if (!valid) {
             throw new Error('Parameter validation failed, ' + (schemaValidator.error.dataPath !== '' ? 'Field: '
                     + schemaValidator.error.dataPath + ', ' : '')
-                    + 'Validation error: ' + schemaValidator.error.message);
+                + 'Validation error: ' + schemaValidator.error.message);
         }
 
         if (schema === 'fetchSchema') {
@@ -251,9 +251,10 @@ module.exports = function (PersistObjectTemplate) {
 
             function fetchPropChecks(fetch, template, name) {
                 Object.keys(fetch).map(function(key) {
-                    if (key in template.defineProperties && isObjectTemplateProperty(template.props[key])) {
+                    var keyTemplate = isFetchKeyInDefineProperties(key, template);
+                    if (keyTemplate) {
                         if (!fetch[key].fetch) return;
-                        fetchPropChecks(fetch[key].fetch, template.props[key].type, template.props[key].type.__name__)
+                        fetchPropChecks(fetch[key].fetch, keyTemplate, keyTemplate.__name__)
                     }
                     else {
                         throw new Error('key used ' + key + ' is not a valid fetch key for the template ' + name);
@@ -261,9 +262,24 @@ module.exports = function (PersistObjectTemplate) {
                 });
             }
 
-            function isObjectTemplateProperty(template) {
-                return ((template.type && template.type.isObjectTemplate) ||
-                    (template.of && template.type === Array && template.of.isObjectTemplate))
+            function getKeyTemplate(key, template) {
+                if (template.type && template.type.isObjectTemplate) {
+                    return template.type;
+                }
+                else if (template.of && template.type === Array && template.of.isObjectTemplate) {
+                    return template.of;
+                }
+            }
+
+            function isFetchKeyInDefineProperties(key, template) {
+                if (key in template.defineProperties) {
+                    return getKeyTemplate(key, template.defineProperties[key]);
+                }
+                else {
+                    return template.__children__.reduce(function(found, child) {
+                        return found || isFetchKeyInDefineProperties(key, child)
+                    }, null);
+                }
             }
         }
 

--- a/test/persist_banking_pgsql.js
+++ b/test/persist_banking_pgsql.js
@@ -1214,11 +1214,8 @@ describe('Banking from pgsql Example', function () {
         }).catch(function(e) {done(e)});
     });
 
-    // it('closes the database', function (done) {
-    //     persist_banking_pgsql.js.close().then(function () {
-    //         console.log('ending banking');
-    //         done()
-    //     });
-    // });
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
 });

--- a/test/persist_fetch.js
+++ b/test/persist_fetch.js
@@ -42,6 +42,9 @@ describe('persistor transaction checks', function () {
                 }),
             knex.schema.dropTableIfExists(schemaTable)]);
     })
+    after('closes the database', function () {
+        return knex.destroy();
+    });
     beforeEach('arrange', function () {
         ObjectTemplate = require('supertype');
         PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);

--- a/test/persist_fetch_children.js
+++ b/test/persist_fetch_children.js
@@ -37,6 +37,9 @@ describe('persistor transaction checks', function () {
             }),
             knex.schema.dropTableIfExists(schemaTable)]);
     })
+    after('closes the database', function () {
+        return knex.destroy();
+    });
     beforeEach('arrange', function () {
         ObjectTemplate = require('supertype');
         PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);

--- a/test/persist_idmap.js
+++ b/test/persist_idmap.js
@@ -51,6 +51,7 @@ describe('IdMap checks', function () {
         });
     });
 
+
     it('checking flags..', function() {
         var cust = new Customer();
         var address1 = new Address();

--- a/test/persist_newapi_tests.js
+++ b/test/persist_newapi_tests.js
@@ -39,6 +39,9 @@ describe('persistor transaction checks', function () {
                 }),
             knex.schema.dropTableIfExists(schemaTable)]);
     })
+    after('closes the database', function () {
+        return knex.destroy();
+    });
     beforeEach('arrange', function () {
         ObjectTemplate = require('supertype');
         PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);

--- a/test/persist_parent_subset.js
+++ b/test/persist_parent_subset.js
@@ -46,6 +46,9 @@ describe('persistor transaction checks', function () {
             knex.schema.dropTableIfExists(schemaTable)
         ]).should.notify(done);
     });
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
     it('Creating multiple levels objects, only parent object can have the schema entry', function () {
         schema.Employee = {};

--- a/test/persist_polymorphic.js
+++ b/test/persist_polymorphic.js
@@ -521,6 +521,9 @@ describe('type mapping tests for parent/child relations', function () {
             knex.schema.dropTableIfExists(schemaTable)
         ]).should.notify(done);
     })
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
     it('Parent type with an associated child will add add the fields from the child tables to the parent table', function (done) {
         return PersistObjectTemplate.createKnexTable(Parent).then(function () {

--- a/test/persist_schema_indexdefchanges.js
+++ b/test/persist_schema_indexdefchanges.js
@@ -243,6 +243,9 @@ describe('index synchronization checks', function () {
             knex.schema.dropTableIfExists('IndexSyncTable')
         ]).should.notify(done);
     });
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
 
     it('synchronize the table without defining the indexes and make sure that the process does not make any entries to the schema table', function () {

--- a/test/persist_schema_updates.js
+++ b/test/persist_schema_updates.js
@@ -200,7 +200,9 @@ describe('schema update checks', function () {
 
         ]).should.notify(done);
     });
-
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
 
 

--- a/test/persist_transaction.js
+++ b/test/persist_transaction.js
@@ -52,6 +52,9 @@ describe('persistor transaction checks', function () {
             knex.schema.dropTableIfExists(schemaTable)
         ]).should.notify(done);
     });
+    after('closes the database', function () {
+        return knex.destroy();
+    });
 
     it('create a simple table', function () {
         schema.Employee = {};


### PR DESCRIPTION
Modified for the following three issues:
1. New API fetch spec validations are not working when fetch spec includes the references from child templates.
2. returning the object from cache should check whether all the references mentioned in the fetch spec are available in the cache.
3. persistor tests can fail if we don't destroy the knex pools.