### PR TITLE
fetch spec validation fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 2.2.6
+* Fixed fetch spec validation.
 ## 2.2.5
 * Fixed fetch spec validation to consider the complete object hierarchy.
 ## 2.2.4

--- a/lib/util.js
+++ b/lib/util.js
@@ -279,6 +279,11 @@ module.exports = function (PersistObjectTemplate) {
                 if (key in templateProperties) {
                     return getKeyTemplate(templateProperties[key]);
                 }
+                else {
+                    return template.__children__.reduce(function(keyTemplate, child) {
+                        return keyTemplate || isFetchKeyInDefineProperties(key, child)
+                    }, null);
+                }
 
                 return null;
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/selsamman/persistor",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.*",

--- a/test/supertype/Address.ts
+++ b/test/supertype/Address.ts
@@ -34,10 +34,10 @@ export class Address extends Persistable(Supertype) {
     @property()
     type: string;
 
-    @property({type: ReturnedMail})
+    @property({getType: () => ReturnedMail})
     returnedMail: Array<ReturnedMail> = [];
 
-    @property({getType: () => {return Account}})
+    @property({getType: () => Account})
     account: Account;
 
     addReturnedMail (date) {

--- a/test/supertype/Customer.ts
+++ b/test/supertype/Customer.ts
@@ -40,7 +40,7 @@ export class Customer extends Persistable(Supertype) {
     @property()
     nullString: string = null;
 
-    @property({type: Role})
+    @property({getType: () => Role})
     roles:  Array<Role> = [];
 
     @property()
@@ -49,10 +49,10 @@ export class Customer extends Persistable(Supertype) {
     @property()
     type: string = 'primary';
 
-    @property({fetch: true, type: Customer})
+    @property({fetch: true, getType: () => Customer})
     referrers:  Array<Customer>;
 
-    @property({fetch: true, type: Customer})
+    @property({fetch: true, getType: () => Customer})
     secondaryReferrers:  Array<Customer> = [];
 
     addAddress (type, lines, city, state, zip) {

--- a/test/supertype/Employee.ts
+++ b/test/supertype/Employee.ts
@@ -16,6 +16,6 @@ export class Employee extends Persistable(Supertype) {
     @property()
     lastName: string = '';
 
-    @property({type: Responsibility})
+    @property({getType: () => Responsibility})
     responsibilities:  Array<Responsibility> = [];
 }

--- a/test/supertype/ExtendedCustomer.ts
+++ b/test/supertype/ExtendedCustomer.ts
@@ -10,4 +10,7 @@ export class ExtendedCustomer extends Customer {
 
     @property()
     extendedProp: string = '';
+
+    @property({fetch: true, getType: () => Customer})
+    extendedReferrers:  Array<Customer>;
 }

--- a/test/supertype/persist_banking_pgsql.ts
+++ b/test/supertype/persist_banking_pgsql.ts
@@ -282,6 +282,17 @@ describe('Banking from pgsql Example', function () {
         })
     });
 
+    it('Can use subtype properties in fetch spec', function (done) {
+        Customer.persistorFetchByQuery(null, {fetch: {extendedReferrers: true}}).then (function (customers) {
+            expect(customers[0].primaryAddresses.length + customers[0].secondaryAddresses.length +
+                customers[1].primaryAddresses.length + customers[1].secondaryAddresses.length +
+                customers[2].primaryAddresses.length + customers[2].secondaryAddresses.length).to.equal(5);
+            done();
+        }).catch(function(e) {
+            done(e)
+        })
+    });
+
     it('Accounts sloppily replace addresses', function (done) {
         sam.primaryAddresses.splice(0, 1);
         sam.addAddress('primary', ['500 East 83d', 'Apt 1E'], 'New York', 'NY', '10028');


### PR DESCRIPTION
I've removed this else condition when I was fixing the logic earlier, but we need to have this to include the properties defined in the subtypes into fetch spec.