### PR TITLE
Minor fixes for the issues observed in policy admin use cases

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 2.3.1
+* Fixed error message to include the property name when changing the types.
+* Fixed to check for Persistor property when looking for the status of the object in cache.
 ## 2.3.0
 * Adding change tracking feature.
 ## 2.2.6

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -535,7 +535,8 @@ module.exports = function (PersistObjectTemplate) {
                         }
                         else {
                             if (!iscompatible(props[prop].type.name, info[propToColumnName(prop)].type)) {
-                                throw new Error('changing types for the fields is not allowed, please use scripts to make these changes');
+                                throw new Error('Changing the type of ' + prop + ' on ' + table
+                                    + ', changing types for the fields is not allowed, please use scripts to make these changes');
                             }
                         }
                     }

--- a/lib/knex/query.js
+++ b/lib/knex/query.js
@@ -470,7 +470,8 @@ module.exports = function (PersistObjectTemplate) {
 
             function allRequiredChildrenAvailableInCache(cachedObject, fetchSpec) {
                 return Object.keys(fetchSpec).reduce(function(loaded, currentObj) {
-                    return loaded && (!fetchSpec[currentObj] || cachedObject[currentObj + 'Persistor'].isFetched)
+                    return loaded && (!fetchSpec[currentObj] ||
+                        (cachedObject[currentObj + 'Persistor'] && cachedObject[currentObj + 'Persistor'].isFetched))
                 }, true);
             }
         };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/selsamman/persistor",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.*",

--- a/test/persist_newapi_extend.js
+++ b/test/persist_newapi_extend.js
@@ -20,7 +20,7 @@ var knex = require('knex')({
 
 var schema = {};
 var schemaTable = 'index_schema_history';
-var Employee, Person, empId;
+var Employee, Person, Manager, empId, Address;
 var PersistObjectTemplate, ObjectTemplate;
 
 describe('persistor transaction checks', function () {
@@ -36,27 +36,51 @@ describe('persistor transaction checks', function () {
         PersistObjectTemplate = require('../index.js')(ObjectTemplate, null, ObjectTemplate);
         schema.Person = {};
         schema.Person.table =  'tx_person';
+        schema.Person.documentOf =  'tx_person';
+        schema.Employee = {};
         schema.Person.parents = {
             manager: {
                 id: 'person_id'
+            },
+            address: {
+                id: 'address_id'
             }
         };
-        //schema.Employee.documentOf = 'tx_person';
         Person = PersistObjectTemplate.create('Person', {
             firstName: {type: String},
             lastName: {type: String}
         });
+
+        Address = PersistObjectTemplate.create('Address', {
+            address1: {type: String},
+            address2: {type: String}
+        });
+
+        schema.Address = {};
+
+
         Employee = Person.extend('Employee', {
             salary: {type: Number},
             manager: {type: Person}
+        });
+
+        Manager = Person.extend('Manager', {
+            salary: {type: Number},
+            address: {type: Address}
         });
 
         var emp = new Employee();
         emp.firstName = 'test firstName';
         emp.lastName = 'lastName';
         emp.salary = 10000;
-        var manager = new Person();
+        var manager = new Manager();
         manager.firstName = 'manager';
+
+        var add = new Address();
+        add.address1 = 'adress 1';
+        add.address2 = 'adress 2';
+        manager.address = add;
+
         emp.manager = manager;
 
         (function () {
@@ -70,6 +94,7 @@ describe('persistor transaction checks', function () {
         function prepareData() {
             PersistObjectTemplate.performInjections();
             return syncTable(Employee)
+                .then(syncTable.bind(this, Address))
                 .then(createRecords.bind(this));
 
 
@@ -106,5 +131,19 @@ describe('persistor transaction checks', function () {
         }).catch(function(err) {
             expect(err).not.equal(null);
         });
+    });
+
+    it('Use supertype to load all properties defined in the subtypes', function() {
+        return loadPersons()
+            .then(checkSubTypes);
+
+        function loadPersons() {
+            return Person.persistorFetchByQuery({}, {fetch: {manager: true, address: true}})
+        }
+
+        function checkSubTypes(persons) {
+            expect(persons[0].manager).not.equal(undefined);
+            expect(persons[1].address).not.equal(undefined);
+        }
     });
 });


### PR DESCRIPTION
Following are the changes:
1. If the property type is changed, error message will include the property name and the table name.
2. Check for persistor property before looking for IsFetched property, this is required if we use the same fetch spec to load multiple subtypes.
3. Added a test case to check if we can load different subtypes using the parent type.