### PR TITLE
Shouldnot sync queryobjects

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 ## 2.3.11
+* Including return to make promise calls to wait when adding comments.
+## 2.3.11
 * Fixed sync tables issue, should not synchronize query templates when schema contains entry to the real templates.
 ## 2.3.10
 * Modified order parameter parsing logic in persistorFetchByQuery.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-## 2.3.11
+## 2.3.12
 * Including return to make promise calls to wait when adding comments.
 ## 2.3.11
 * Fixed sync tables issue, should not synchronize query templates when schema contains entry to the real templates.

--- a/lib/knex/db.js
+++ b/lib/knex/db.js
@@ -437,20 +437,20 @@ module.exports = function (PersistObjectTemplate) {
                     var prop = columnNameToProp(columnName);
                     if (!prop) {
                         PersistObjectTemplate.logger.info({component: 'persistor', module: 'db.synchronizeKnexTableFromTemplate', activity: 'discoverColumns'}, 'Extra column ' + columnName + ' on ' + table);
-                        commentOn(table, columnName, 'now obsolete');
+                        return commentOn(table, columnName, 'now obsolete');
                     } else {
                         if (prop == '_id')
-                            commentOn(table, columnName, 'primary key');
+                            return commentOn(table, columnName, 'primary key');
                         else if (prop.match(/:/)) {
                             prop = prop.substr(1);
                             var fkComment = getForeignKeyDescription(props[prop]);
                             var commentField = getDescription(prop, props[prop])
                             var comment = (commentField === '') ?  fkComment : fkComment + ', ' + commentField;
-                            commentOn(table, columnName, comment);
+                            return commentOn(table, columnName, comment);
                         } else if (prop == '_template')
-                            commentOn(table, columnName, getClassNames(prop));
+                            return commentOn(table, columnName, getClassNames(prop));
                         else if (prop != '__version__')
-                            commentOn(table, columnName, getDescription(prop, props[prop]));
+                            return commentOn(table, columnName, getDescription(prop, props[prop]));
                     }
                 }
             });
@@ -520,6 +520,7 @@ module.exports = function (PersistObjectTemplate) {
                             /*eslint-enable no-console*/
                         });
                 }
+                return;
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/selsamman/persistor",
-    "version": "2.3.11",
+    "version": "2.3.12",
     "dependencies": {
         "q": "1.x",
         "supertype": "2.2.*",


### PR DESCRIPTION
We are seeing excessive locks when adding comments to the fields. Making promise calls to wait will alleviate the issues